### PR TITLE
fix: Desync comprehensive ego gift list from floor-wise ego gift list

### DIFF
--- a/frontend/src/components/floorTheme/FloorGiftSelectorPane.tsx
+++ b/frontend/src/components/floorTheme/FloorGiftSelectorPane.tsx
@@ -19,7 +19,6 @@ import {
   decodeGiftSelection,
   getCascadeIngredients,
 } from '@/lib/egoGiftEncoding'
-import { usePlannerEditorStoreSafe } from '@/stores/usePlannerEditorStore'
 import type { EGOGiftListItem } from '@/types/EGOGiftTypes'
 import type { EnhancementLevel, DungeonIdx } from '@/lib/constants'
 import { DUNGEON_IDX } from '@/lib/constants'
@@ -64,10 +63,6 @@ export function FloorGiftSelectorPane({
   onGiftSelectionChange,
 }: FloorGiftSelectorPaneProps) {
   const { t } = useTranslation(['planner', 'common'])
-
-  // Store state for comprehensive gift sync (safe - returns undefined outside context)
-  const comprehensiveGiftIds = usePlannerEditorStoreSafe((s) => s.comprehensiveGiftIds)
-  const setComprehensiveGiftIds = usePlannerEditorStoreSafe((s) => s.setComprehensiveGiftIds)
 
   const { spec, i18n } = useEGOGiftListData()
 
@@ -135,8 +130,6 @@ export function FloorGiftSelectorPane({
   // Use ref to always access latest state in stable callback
   const selectedGiftIdsRef = useRef(selectedGiftIds)
   selectedGiftIdsRef.current = selectedGiftIds
-  const comprehensiveGiftIdsRef = useRef(comprehensiveGiftIds ?? new Set<string>())
-  comprehensiveGiftIdsRef.current = comprehensiveGiftIds ?? new Set<string>()
 
   /**
    * Handle enhancement selection with toggle logic and cascade
@@ -144,9 +137,7 @@ export function FloorGiftSelectorPane({
   const handleEnhancementSelect = useCallback((giftId: string, enhancement: EnhancementLevel) => {
     startTransition(() => {
       const current = selectedGiftIdsRef.current
-      const currentComprehensive = comprehensiveGiftIdsRef.current
       const newSelection = new Set(current)
-      const newComprehensive = new Set(currentComprehensive)
 
       const existingEncodedId = findEncodedGiftId(giftId, current)
 
@@ -155,7 +146,6 @@ export function FloorGiftSelectorPane({
 
         if (currentEnhancement === enhancement) {
           newSelection.delete(existingEncodedId)
-          newComprehensive.delete(existingEncodedId)
         } else {
           newSelection.delete(existingEncodedId)
           const newEncodedId = encodeGiftSelection(enhancement, giftId)
@@ -164,7 +154,6 @@ export function FloorGiftSelectorPane({
       } else {
         const newEncodedId = encodeGiftSelection(enhancement, giftId)
         newSelection.add(newEncodedId)
-        newComprehensive.add(newEncodedId)
 
         const giftSpec = specById.get(giftId)
         if (giftSpec) {
@@ -185,19 +174,13 @@ export function FloorGiftSelectorPane({
             if (isObtainable && !findEncodedGiftId(ingredientIdStr, newSelection)) {
               newSelection.add(encodeGiftSelection(0, ingredientIdStr))
             }
-            // Always add to comprehensive (no theme pack restriction)
-            const ingredientEncodedId = encodeGiftSelection(0, ingredientIdStr)
-            newComprehensive.add(ingredientEncodedId)
           }
         }
       }
 
       onGiftSelectionChange(newSelection)
-      if (setComprehensiveGiftIds) {
-        setComprehensiveGiftIds(newComprehensive)
-      }
     })
-  }, [onGiftSelectionChange, setComprehensiveGiftIds, specById, themePackId])
+  }, [onGiftSelectionChange, specById, themePackId])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -211,16 +194,7 @@ export function FloorGiftSelectorPane({
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => {
-                    if (setComprehensiveGiftIds && comprehensiveGiftIds) {
-                      const newComprehensive = new Set(comprehensiveGiftIds)
-                      for (const encodedId of selectedGiftIds) {
-                        newComprehensive.delete(encodedId)
-                      }
-                      setComprehensiveGiftIds(newComprehensive)
-                    }
-                    onGiftSelectionChange(new Set())
-                  }}
+                  onClick={() => { onGiftSelectionChange(new Set()) }}
                 >
                   {t('common:reset')}
                 </Button>

--- a/frontend/src/components/plannerViewer/ComprehensiveGiftGridTracker.test.tsx
+++ b/frontend/src/components/plannerViewer/ComprehensiveGiftGridTracker.test.tsx
@@ -9,21 +9,21 @@ vi.mock('@/hooks/useEGOGiftListData', () => ({
   useEGOGiftListData: () => ({
     spec: {
       gift1: {
-        tag: 'ATTACK',
+        tag: ['ATTACK'],
         keyword: 'Burn',
         attributeType: 'WRATH',
         themePack: 'pack1',
         maxEnhancement: 3,
       },
       gift2: {
-        tag: 'DEFENSE',
+        tag: ['DEFENSE'],
         keyword: 'Bleed',
         attributeType: 'LUST',
         themePack: 'pack2',
         maxEnhancement: 3,
       },
       gift3: {
-        tag: 'ATTACK',
+        tag: ['ATTACK'],
         keyword: 'Tremor',
         attributeType: 'PRIDE',
         themePack: 'pack1',
@@ -127,7 +127,7 @@ describe('ComprehensiveGiftGridTracker', () => {
       expect(getByTestId('gift-card-gift1')).toBeDefined()
     })
 
-    it('does not display a gift present in a floor giftIds but absent from comprehensiveGiftIds', () => {
+    it('display gifts present in both a floor giftIds and comprehensiveGiftIds', () => {
       const floorSelections: SerializableFloorSelection[] = [
         { themePackId: 'pack1', difficulty: 0, giftIds: ['gift2'] },
       ]
@@ -141,7 +141,8 @@ describe('ComprehensiveGiftGridTracker', () => {
         { wrapper: createWrapper() }
       )
 
-      expect(queryByTestId('gift-card-gift2')).toBeNull()
+      expect(queryByTestId('gift-card-gift1')).toBeDefined()
+      expect(queryByTestId('gift-card-gift2')).toBeDefined()
     })
   })
 

--- a/frontend/src/components/plannerViewer/ComprehensiveGiftGridTracker.tsx
+++ b/frontend/src/components/plannerViewer/ComprehensiveGiftGridTracker.tsx
@@ -25,7 +25,7 @@ interface ComprehensiveGiftGridTrackerProps {
   onToggleEgoGiftDone?: (encodedId: string) => void
   readOnly?: boolean
   /** Authoritative gift list from saved plan content. When provided, used as-is instead of aggregating from floorSelections. */
-  comprehensiveGiftIds?: string[]
+  comprehensiveGiftIds: string[]
 }
 
 interface DecodedGift {
@@ -45,7 +45,7 @@ export function ComprehensiveGiftGridTracker({
   egoGiftDoneMarks,
   onToggleEgoGiftDone,
   readOnly,
-  comprehensiveGiftIds,
+  comprehensiveGiftIds = [],
 }: ComprehensiveGiftGridTrackerProps) {
   const { t } = useTranslation(['planner', 'common'])
   const { spec, i18n } = useEGOGiftListData()
@@ -60,10 +60,7 @@ export function ComprehensiveGiftGridTracker({
 
   // Use authoritative comprehensiveGiftIds when provided; fall back to aggregating from floors
   const allComprehensiveGiftIds = useMemo(() => {
-    if (comprehensiveGiftIds) {
-      return new Set(comprehensiveGiftIds)
-    }
-    const allGifts = new Set<string>()
+    const allGifts = new Set<string>(comprehensiveGiftIds)
     floorSelections.forEach((selection) => {
       selection.giftIds.forEach((giftId) => allGifts.add(giftId))
     })

--- a/static/i18n/CN/planner.json
+++ b/static/i18n/CN/planner.json
@@ -114,7 +114,7 @@
       "egoGiftSelection": "已选择",
       "egoGiftObservation": "E.G.O饰品观测",
       "selectEgoGifts": "选择E.G.O 饰品",
-      "selectComprehensiveEgoGifts": "选择E.G.O 饰品（将与各层 E.G.O 饰品选择联动）",
+      "selectComprehensiveEgoGifts": "选择E.G.O 饰品",
       "selectedEgoGifts": "已选E.G.O饰品",
       "comprehensiveEgoGiftList": "E.G.O饰品选择",
       "comprehensiveEgoGiftListView": "E.G.O饰品",

--- a/static/i18n/EN/planner.json
+++ b/static/i18n/EN/planner.json
@@ -114,7 +114,7 @@
       "egoGiftSelection": "Selected",
       "egoGiftObservation": "E.G.O Gift Observation",
       "selectEgoGifts": "Select E.G.O Gifts",
-      "selectComprehensiveEgoGifts": "Select E.G.O Gifts (Synced with floor E.G.O Gift selection)",
+      "selectComprehensiveEgoGifts": "Select E.G.O Gifts",
       "selectedEgoGifts": "Selected E.G.O Gifts",
       "comprehensiveEgoGiftList": "E.G.O Gift Selection",
       "comprehensiveEgoGiftListView": "E.G.O Gifts",

--- a/static/i18n/JP/planner.json
+++ b/static/i18n/JP/planner.json
@@ -114,7 +114,7 @@
       "egoGiftSelection": "選択済み",
       "egoGiftObservation": "E.G.Oギフト観測",
       "selectEgoGifts": "E.G.Oギフトを選択してください",
-      "selectComprehensiveEgoGifts": "E.G.Oギフトを選択してください（階層別E.G.Oギフト選択と連動します）",
+      "selectComprehensiveEgoGifts": "E.G.Oギフトを選択してください",
       "selectedEgoGifts": "選択中のE.G.Oギフト",
       "comprehensiveEgoGiftList": "E.G.Oギフト選択",
       "comprehensiveEgoGiftListView": "E.G.Oギフト",

--- a/static/i18n/KR/planner.json
+++ b/static/i18n/KR/planner.json
@@ -114,7 +114,7 @@
       "egoGiftSelection": "선택됨",
       "egoGiftObservation": "E.G.O 기프트 관측",
       "selectEgoGifts": "E.G.O 기프트를 선택하세요",
-      "selectComprehensiveEgoGifts": "E.G.O 기프트를 선택하세요 (층별 E.G.O 기프트 선택과 연동됩니다)",
+      "selectComprehensiveEgoGifts": "E.G.O 기프트를 선택하세요",
       "selectedEgoGifts": "선택된 E.G.O 기프트",
       "comprehensiveEgoGiftList": "E.G.O 기프트 선택",
       "comprehensiveEgoGiftListView": "E.G.O 기프트",


### PR DESCRIPTION
For now, each list handles its own ego gifts separately and they are merged in ComprehensiveGiftGridTracker. This change does not break the existing plans.