### PR TITLE
feat: align FE validators with BE strict/non-strict modes

### DIFF
--- a/frontend/src/components/plannerViewer/PlannerDetailHeader.tsx
+++ b/frontend/src/components/plannerViewer/PlannerDetailHeader.tsx
@@ -38,7 +38,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { formatUsername } from '@/lib/formatUsername'
 import { getKeywordIconPath } from '@/lib/assetPaths'
 import { I18N_LOCALE_MAP, MD_CATEGORY_COLORS, MD_CATEGORY_TEXT_COLORS, RECOMMENDED_THRESHOLD } from '@/lib/constants'
-import { validatePlannerUserFriendly } from '@/lib/plannerHelpers'
+import { validatePlannerForSave, toUserFriendlyError } from '@/lib/plannerHelpers'
 
 import type { MDCategory } from '@/lib/constants'
 import type { PublishedPlannerDetail } from '@/types/PlannerListTypes'
@@ -196,15 +196,16 @@ export function PlannerDetailHeader({
     if (!savedPlanner.metadata.published && savedPlanner.config.type === 'MIRROR_DUNGEON') {
       const content = savedPlanner.content as MDPlannerContent
       const category = savedPlanner.config.category as MDCategory
-      const error = validatePlannerUserFriendly(
+      const { isValid, errors } = validatePlannerForSave(
         savedPlanner.metadata.title,
-        content.floorSelections,
+        content,
         category,
         egoGiftSpec,
         egoGiftI18n
       )
-      if (error) {
-        toast.error(t(error.key, error.params))
+      if (!isValid) {
+        const friendly = toUserFriendlyError(errors[0])
+        toast.error(t(friendly.key, friendly.params))
         return
       }
     }
@@ -258,6 +259,23 @@ export function PlannerDetailHeader({
     setShowPublishWarning(false)
 
     try {
+      // Validate before upload (strict: title + theme packs required)
+      const content = savedPlanner.content as MDPlannerContent
+      const category = savedPlanner.config.category as MDCategory
+      const { isValid, errors } = validatePlannerForSave(
+        savedPlanner.metadata.title,
+        content,
+        category,
+        egoGiftSpec,
+        egoGiftI18n
+      )
+      if (!isValid) {
+        const friendly = toUserFriendlyError(errors[0])
+        toast.error(t(friendly.key, friendly.params))
+        setIsUploadingForPublish(false)
+        return
+      }
+
       // Step 1: Upload plan to server (force sync even though sync is disabled)
       await syncAdapter.syncToServer(savedPlanner)
 

--- a/frontend/src/hooks/usePlannerSave.ts
+++ b/frontend/src/hooks/usePlannerSave.ts
@@ -9,12 +9,12 @@ import { serializeSets } from '@/schemas/PlannerSchemas'
 import { ConflictError, BannedError, TimedOutError } from '@/lib/api'
 import { queryClient } from '@/lib/queryClient'
 import { AUTO_SAVE_DEBOUNCE_MS } from '@/lib/constants'
-import { validatePlannerUserFriendly } from '@/lib/plannerHelpers'
+import { validatePlannerUserFriendly, validatePlannerForSave, toUserFriendlyError } from '@/lib/plannerHelpers'
 import type { MDCategory, PlannerType } from '@/lib/constants'
 import type { SinnerEquipment, SkillEAState } from '@/types/DeckTypes'
 import type { FloorThemeSelection } from '@/types/ThemePackTypes'
 import type { NoteContent } from '@/types/NoteEditorTypes'
-import type { SaveablePlanner, ConflictState, ConflictResolutionChoice, PlannerConfig, PlannerContent } from '@/types/PlannerTypes'
+import type { SaveablePlanner, ConflictState, ConflictResolutionChoice, PlannerConfig, PlannerContent, MDPlannerContent } from '@/types/PlannerTypes'
 
 /**
  * SSR safety check
@@ -388,23 +388,38 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
       status
     )
 
-    // User-friendly validation for published planners (MD only)
-    if (isCurrentlyPublished && plannerType === 'MIRROR_DUNGEON') {
-      const validationError = validatePlannerUserFriendly(
-        currentState.title,
-        currentState.floorSelections,
-        currentState.category,
-        egoGiftSpec,
-        egoGiftI18n
-      )
-      if (validationError) {
-        // Serialize error info as JSON for later parsing
-        const errorMessage = JSON.stringify({ key: validationError.key, params: validationError.params })
+    // Two-tier validation for MD planners (non-strict for draft, strict for published)
+    if (plannerType === 'MIRROR_DUNGEON') {
+      const throwValidationError = (friendly: { key: string; params?: Record<string, string> }) => {
+        const errorMessage = JSON.stringify({ key: friendly.key, params: friendly.params })
         const error = new Error(errorMessage)
         ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).code = 'userFriendlyValidation'
-        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nKey = validationError.key
-        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nParams = validationError.params
+        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nKey = friendly.key
+        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nParams = friendly.params
         throw error
+      }
+
+      const content = saveable.content as MDPlannerContent
+
+      if (isCurrentlyPublished) {
+        // Strict: title + theme packs required, full difficulty enforced
+        const { isValid, errors } = validatePlannerForSave(
+          currentState.title,
+          content,
+          currentState.category,
+          egoGiftSpec,
+          egoGiftI18n
+        )
+        if (!isValid) throwValidationError(toUserFriendlyError(errors[0]))
+      } else {
+        // Non-strict: structural checks only, title/theme packs optional
+        const validationError = validatePlannerUserFriendly(
+          content,
+          currentState.category,
+          egoGiftSpec,
+          egoGiftI18n
+        )
+        if (validationError) throwValidationError(validationError)
       }
     }
 

--- a/frontend/src/lib/__tests__/plannerHelpers.test.ts
+++ b/frontend/src/lib/__tests__/plannerHelpers.test.ts
@@ -1,0 +1,354 @@
+/**
+ * plannerHelpers.test.ts
+ *
+ * Unit tests for planner validation utility functions.
+ * Tests both strict (publish) and non-strict (sync) validator modes,
+ * mirroring the backend PlannerContentValidator strict/relaxed split.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  isGiftAffordableForThemePack,
+  getUnaffordableGiftIds,
+  validateEquipment,
+  validateFloorThemePacksForSave,
+  validatePlannerForSave,
+  validatePlannerUserFriendly,
+  toUserFriendlyError,
+} from '../plannerHelpers'
+import type { EGOGiftSpec } from '@/types/EGOGiftTypes'
+import type { FloorThemeSelection } from '@/types/ThemePackTypes'
+import type { MDPlannerContent } from '@/types/PlannerTypes'
+import type { SinnerEquipment, SkillEAState } from '@/types/DeckTypes'
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeValidEquipment(): Record<string, SinnerEquipment> {
+  const equipment: Record<string, SinnerEquipment> = {}
+  for (let i = 1; i <= 12; i++) {
+    const key = String(i).padStart(2, '0')
+    equipment[key] = {
+      identity: { id: `identity_${i}` },
+      egos: { ZAYIN: { id: `ego_zayin_${i}` } },
+    } as SinnerEquipment
+  }
+  return equipment
+}
+
+function makeValidSkillEAState(): Record<string, SkillEAState> {
+  const state: Record<string, SkillEAState> = {}
+  for (let i = 1; i <= 12; i++) {
+    const key = String(i).padStart(2, '0')
+    // Slots 0+1+2 must sum to 6
+    state[key] = { 0: 3, 1: 2, 2: 1 } as unknown as SkillEAState
+  }
+  return state
+}
+
+/**
+ * Creates a valid serialized floor selection array for the given floor count.
+ * Theme pack IDs are auto-generated as unique strings ('1001', '1002', ...).
+ * Difficulty is Hard (1) which satisfies all category requirements.
+ */
+function makeValidFloorSelections(
+  count: number,
+  opts: { difficulty?: number; startPackId?: number } = {}
+) {
+  const { difficulty = 1, startPackId = 1001 } = opts
+  return Array.from({ length: count }, (_, i) => ({
+    themePackId: String(startPackId + i),
+    difficulty,
+    giftIds: [] as string[],
+  }))
+}
+
+/**
+ * Creates a valid MDPlannerContent for the given category.
+ * - 5F: 5 floors, Hard difficulty
+ * - 10F: 10 floors, Hard difficulty
+ * - 15F: floors 1-10 Hard, floors 11-15 Extreme (3)
+ */
+function makeValidContent(category: '5F' | '10F' | '15F' = '5F'): MDPlannerContent {
+  const floorCountMap = { '5F': 5, '10F': 10, '15F': 15 }
+  const count = floorCountMap[category]
+  const floorSelections = makeValidFloorSelections(count)
+
+  if (category === '15F') {
+    for (let i = 10; i < 15; i++) {
+      floorSelections[i].difficulty = 3 // EXTREME
+    }
+  }
+
+  return {
+    selectedKeywords: [],
+    selectedBuffIds: [],
+    selectedGiftKeyword: null,
+    selectedGiftIds: [],
+    observationGiftIds: [],
+    comprehensiveGiftIds: [],
+    equipment: makeValidEquipment(),
+    deploymentOrder: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    skillEAState: makeValidSkillEAState(),
+    floorSelections,
+    sectionNotes: {},
+  }
+}
+
+// ============================================================================
+// isGiftAffordableForThemePack
+// ============================================================================
+
+describe('isGiftAffordableForThemePack', () => {
+  it('universal gift (empty themePack) is available in any theme pack', () => {
+    const gift = { themePack: [] } as unknown as EGOGiftSpec
+    expect(isGiftAffordableForThemePack(gift, '1024')).toBe(true)
+    expect(isGiftAffordableForThemePack(gift, '1110')).toBe(true)
+  })
+
+  it('restricted gift is available only for its listed pack', () => {
+    const gift = { themePack: ['1024'] } as unknown as EGOGiftSpec
+    expect(isGiftAffordableForThemePack(gift, '1024')).toBe(true)
+    expect(isGiftAffordableForThemePack(gift, '1110')).toBe(false)
+  })
+})
+
+// ============================================================================
+// getUnaffordableGiftIds
+// ============================================================================
+
+describe('getUnaffordableGiftIds', () => {
+  const spec: Record<string, EGOGiftSpec> = {
+    '9220': { themePack: ['1024'] } as unknown as EGOGiftSpec,
+  }
+
+  it('base gift ID on wrong pack returns that ID', () => {
+    const result = getUnaffordableGiftIds(new Set(['9220']), '1110', spec)
+    expect(result).toEqual(['9220'])
+  })
+
+  it('enhanced gift ID (19220) strips prefix to look up base ID 9220', () => {
+    // '19220' → getBaseGiftId → '9220' → not in '1110' → unaffordable
+    const result = getUnaffordableGiftIds(new Set(['19220']), '1110', spec)
+    expect(result).toEqual(['19220'])
+  })
+
+  it('gift on correct pack returns empty array', () => {
+    const result = getUnaffordableGiftIds(new Set(['9220']), '1024', spec)
+    expect(result).toEqual([])
+  })
+
+  it('gift not in spec is silently skipped', () => {
+    const result = getUnaffordableGiftIds(new Set(['9999']), '1110', spec)
+    expect(result).toEqual([])
+  })
+})
+
+// ============================================================================
+// validateEquipment
+// ============================================================================
+
+describe('validateEquipment', () => {
+  it('all 12 sinners with identity + ZAYIN returns no errors', () => {
+    expect(validateEquipment(makeValidEquipment())).toHaveLength(0)
+  })
+
+  it('missing sinner key returns EQUIPMENT_MISSING_SINNER', () => {
+    const equipment = makeValidEquipment()
+    delete equipment['01']
+    const errors = validateEquipment(equipment)
+    expect(errors.some(e => e.code === 'EQUIPMENT_MISSING_SINNER')).toBe(true)
+  })
+
+  it('sinner without identity returns EQUIPMENT_MISSING_IDENTITY', () => {
+    const equipment = makeValidEquipment()
+    equipment['01'] = { identity: null, egos: { ZAYIN: { id: 'z' } } } as unknown as SinnerEquipment
+    const errors = validateEquipment(equipment)
+    expect(errors.some(e => e.code === 'EQUIPMENT_MISSING_IDENTITY')).toBe(true)
+  })
+
+  it('sinner without ZAYIN returns EQUIPMENT_MISSING_ZAYIN', () => {
+    const equipment = makeValidEquipment()
+    equipment['01'] = { identity: { id: 'i' }, egos: {} } as unknown as SinnerEquipment
+    const errors = validateEquipment(equipment)
+    expect(errors.some(e => e.code === 'EQUIPMENT_MISSING_ZAYIN')).toBe(true)
+  })
+})
+
+// ============================================================================
+// validateFloorThemePacksForSave
+// ============================================================================
+
+describe('validateFloorThemePacksForSave', () => {
+  function makeFloors(packs: (string | null)[]): FloorThemeSelection[] {
+    return packs.map(themePackId => ({
+      themePackId,
+      difficulty: 1,
+      giftIds: new Set<string>(),
+    }))
+  }
+
+  it('all packs present and unique returns no errors', () => {
+    const floors = makeFloors(['1001', '1002', '1003', '1004', '1005'])
+    expect(validateFloorThemePacksForSave(floors, 5)).toHaveLength(0)
+  })
+
+  it('missing pack on floor 2 returns FLOOR_MISSING_THEME_PACK', () => {
+    const floors = makeFloors(['1001', null, '1003', '1004', '1005'])
+    const errors = validateFloorThemePacksForSave(floors, 5)
+    expect(errors.some(e => e.code === 'FLOOR_MISSING_THEME_PACK' && e.floorNumber === 2)).toBe(true)
+  })
+
+  it('duplicate pack returns FLOOR_DUPLICATE_THEME_PACK', () => {
+    const floors = makeFloors(['1001', '1001', '1003', '1004', '1005'])
+    const errors = validateFloorThemePacksForSave(floors, 5)
+    expect(errors.some(e => e.code === 'FLOOR_DUPLICATE_THEME_PACK')).toBe(true)
+  })
+
+  it('floor 3 has pack but floor 2 missing returns FLOOR_PREREQUISITE_VIOLATION', () => {
+    // Floor 1: pack, Floor 2: null, Floor 3: pack → Floor 3 fires prerequisite violation
+    const floors = makeFloors(['1001', null, '1003'])
+    const errors = validateFloorThemePacksForSave(floors, 3)
+    expect(errors.some(e => e.code === 'FLOOR_PREREQUISITE_VIOLATION' && e.floorNumber === 3)).toBe(true)
+  })
+})
+
+// ============================================================================
+// validatePlannerForSave (strict mode)
+// ============================================================================
+
+describe('validatePlannerForSave (strict)', () => {
+  it('valid publish-ready 5F content returns isValid: true', () => {
+    const { isValid, errors } = validatePlannerForSave('My Plan', makeValidContent('5F'), '5F')
+    expect(isValid).toBe(true)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('empty title returns MISSING_TITLE error', () => {
+    const { isValid, errors } = validatePlannerForSave('', makeValidContent('5F'), '5F')
+    expect(isValid).toBe(false)
+    expect(errors.some(e => e.code === 'MISSING_TITLE')).toBe(true)
+  })
+
+  it('whitespace-only title returns MISSING_TITLE error', () => {
+    const { isValid, errors } = validatePlannerForSave('   ', makeValidContent('5F'), '5F')
+    expect(isValid).toBe(false)
+    expect(errors.some(e => e.code === 'MISSING_TITLE')).toBe(true)
+  })
+
+  it('missing theme pack on active floor returns FLOOR_MISSING_THEME_PACK', () => {
+    const content = makeValidContent('5F')
+    content.floorSelections[2].themePackId = null
+    const { isValid, errors } = validatePlannerForSave('My Plan', content, '5F')
+    expect(isValid).toBe(false)
+    expect(errors.some(e => e.code === 'FLOOR_MISSING_THEME_PACK')).toBe(true)
+  })
+
+  it('Normal difficulty on 10F floor returns DIFFICULTY_INVALID_FOR_CATEGORY', () => {
+    const content = makeValidContent('10F')
+    content.floorSelections[0].difficulty = 0 // NORMAL — invalid for 10F
+    const { isValid, errors } = validatePlannerForSave('My Plan', content, '10F')
+    expect(isValid).toBe(false)
+    expect(errors.some(e => e.code === 'DIFFICULTY_INVALID_FOR_CATEGORY')).toBe(true)
+  })
+})
+
+// ============================================================================
+// validatePlannerUserFriendly (non-strict mode)
+// ============================================================================
+
+describe('validatePlannerUserFriendly (non-strict)', () => {
+  it('valid sync-ready content with empty title and no theme packs returns null', () => {
+    const content = makeValidContent('5F')
+    for (const floor of content.floorSelections) floor.themePackId = null
+    // Title is not part of MDPlannerContent — non-strict never checks it
+    expect(validatePlannerUserFriendly(content, '5F')).toBeNull()
+  })
+
+  it('missing theme pack on last floor is allowed (returns null)', () => {
+    const content = makeValidContent('5F')
+    // Null the last floor only — no subsequent floor can trigger a prerequisite violation
+    content.floorSelections[4].themePackId = null
+    expect(validatePlannerUserFriendly(content, '5F')).toBeNull()
+  })
+
+  it('floor 3 has pack but floor 2 missing still returns prerequisite error', () => {
+    const content = makeValidContent('5F')
+    // Floor 2 has no pack, Floor 3 has one → FLOOR_PREREQUISITE_VIOLATION
+    content.floorSelections[1].themePackId = null
+    // floor 2 (index 1) missing, floor 3 (index 2) has pack
+    const result = validatePlannerUserFriendly(content, '5F')
+    expect(result?.key).toBe('pages.plannerMD.validation.corruptedState')
+  })
+
+  it('missing equipment sinner returns corruptedState i18n key', () => {
+    const content = makeValidContent('5F')
+    delete (content.equipment as Record<string, unknown>)['01']
+    const result = validatePlannerUserFriendly(content, '5F')
+    expect(result?.key).toBe('pages.plannerMD.validation.corruptedState')
+  })
+
+  it('unaffordable gift on floor with theme pack returns themePackEgoGiftInconsistency i18n key', () => {
+    const content = makeValidContent('5F')
+    // Floor 1 has themePackId '1001', add gift that's only for '1024'
+    content.floorSelections[0].giftIds = ['9220']
+    const spec: Record<string, EGOGiftSpec> = {
+      '9220': { themePack: ['1024'] } as unknown as EGOGiftSpec,
+    }
+    const result = validatePlannerUserFriendly(content, '5F', spec)
+    expect(result?.key).toBe('pages.plannerMD.publish.themePackEgoGiftInconsistency')
+    expect(result?.params?.pack).toBe('1001') // floor 0's themePackId
+  })
+})
+
+// ============================================================================
+// toUserFriendlyError
+// ============================================================================
+
+describe('toUserFriendlyError', () => {
+  it('MISSING_TITLE → missingTitle key', () => {
+    const result = toUserFriendlyError({ code: 'MISSING_TITLE', message: '' })
+    expect(result.key).toBe('pages.plannerMD.publish.missingTitle')
+  })
+
+  it('FLOOR_MISSING_THEME_PACK → missingThemePack key', () => {
+    const result = toUserFriendlyError({ code: 'FLOOR_MISSING_THEME_PACK', message: '' })
+    expect(result.key).toBe('pages.plannerMD.publish.missingThemePack')
+  })
+
+  it('FLOOR_UNAFFORDABLE_GIFT → themePackEgoGiftInconsistency key with pack/gifts params', () => {
+    const result = toUserFriendlyError({
+      code: 'FLOOR_UNAFFORDABLE_GIFT',
+      message: '',
+      floorNumber: 3,
+      context: { giftNames: 'Gift A, Gift B', themePackId: '1001' },
+    })
+    expect(result.key).toBe('pages.plannerMD.publish.themePackEgoGiftInconsistency')
+    expect(result.params?.pack).toBe('1001')
+    expect(result.params?.gifts).toBe('Gift A, Gift B')
+  })
+
+  it('DIFFICULTY_INVALID_FOR_CATEGORY → requiresHardMode key', () => {
+    const result = toUserFriendlyError({ code: 'DIFFICULTY_INVALID_FOR_CATEGORY', message: '' })
+    expect(result.key).toBe('pages.plannerMD.publish.requiresHardMode')
+  })
+
+  it('structural error codes → corruptedState key', () => {
+    const structuralCodes = [
+      'EQUIPMENT_MISSING_SINNER',
+      'DEPLOYMENT_INVALID_INDEX',
+      'SKILL_EA_MISSING_SINNER',
+      'GIFT_DUPLICATE_ID',
+      'BUFF_EXCEEDS_MAX',
+      'START_GIFT_DUPLICATE_ID',
+      'FLOOR_PREREQUISITE_VIOLATION',
+      'FLOOR_DUPLICATE_THEME_PACK',
+    ] as const
+
+    for (const code of structuralCodes) {
+      const result = toUserFriendlyError({ code: code as never, message: '' })
+      expect(result.key).toBe('pages.plannerMD.validation.corruptedState')
+    }
+  })
+})

--- a/frontend/src/lib/plannerHelpers.ts
+++ b/frontend/src/lib/plannerHelpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { EGO_TYPES, OFFENSIVE_SKILL_SLOTS, FLOOR_COUNTS, DUNGEON_IDX } from '@/lib/constants'
+import { getBaseGiftId } from '@/lib/egoGiftEncoding'
 import type { MDPlannerContent } from '@/types/PlannerTypes'
 import type { FloorThemeSelection } from '@/types/ThemePackTypes'
 import type { SinnerEquipment, SkillEAState } from '@/types/DeckTypes'
@@ -74,7 +75,8 @@ export function getUnaffordableGiftIds(
   egoGiftSpec: Record<string, EGOGiftSpec>
 ): string[] {
   return Array.from(giftIds).filter((giftId) => {
-    const gift = egoGiftSpec[giftId]
+    const baseGiftId = getBaseGiftId(giftId)
+    const gift = egoGiftSpec[baseGiftId]
     if (!gift) return false // Skip non-existent gifts
     return !isGiftAffordableForThemePack(gift, themePackId)
   })
@@ -183,6 +185,13 @@ export interface DifficultyValidationError extends ValidationError {
 }
 
 /**
+ * Title validation error (strict/publish mode only)
+ */
+export interface TitleValidationError extends ValidationError {
+  code: 'MISSING_TITLE'
+}
+
+/**
  * Union type of all validation errors
  */
 export type PlannerValidationError =
@@ -194,6 +203,45 @@ export type PlannerValidationError =
   | StartGiftValidationError
   | FloorValidationError
   | DifficultyValidationError
+  | TitleValidationError
+
+// ============================================================================
+// Error → i18n Mapping
+// ============================================================================
+
+/**
+ * Maps a structured validation error to an i18n key + params for toast display
+ *
+ * Structural errors (equipment, deployment, skill EA, gift IDs, buffs, start gifts)
+ * indicate corrupted planner state — the user cannot meaningfully act on them, so
+ * they collapse to a single generic key. Actionable errors (title, theme pack,
+ * difficulty, affordability) get their own specific keys.
+ */
+export function toUserFriendlyError(
+  error: PlannerValidationError
+): { key: string; params?: Record<string, string> } {
+  switch (error.code) {
+    case 'MISSING_TITLE':
+      return { key: 'pages.plannerMD.publish.missingTitle' }
+    case 'FLOOR_MISSING_THEME_PACK':
+      return { key: 'pages.plannerMD.publish.missingThemePack' }
+    case 'FLOOR_UNAFFORDABLE_GIFT': {
+      const floorError = error as FloorValidationError
+      const ctx = floorError.context as { giftNames?: string; themePackId?: string } | undefined
+      return {
+        key: 'pages.plannerMD.publish.themePackEgoGiftInconsistency',
+        params: {
+          pack: ctx?.themePackId ?? '',
+          gifts: ctx?.giftNames ?? '',
+        },
+      }
+    }
+    case 'DIFFICULTY_INVALID_FOR_CATEGORY':
+      return { key: 'pages.plannerMD.publish.requiresHardMode' }
+    default:
+      return { key: 'pages.plannerMD.validation.corruptedState' }
+  }
+}
 
 // ============================================================================
 // Validation Functions
@@ -817,12 +865,18 @@ function validateFloorGiftAffordability(
  * }
  */
 export function validatePlannerForSave(
+  title: string | undefined,
   content: MDPlannerContent,
   category: MDCategory,
   egoGiftSpec?: Record<string, EGOGiftSpec>,
   egoGiftI18n?: Record<string, string>
 ): { isValid: boolean; errors: PlannerValidationError[] } {
   const errors: PlannerValidationError[] = []
+
+  // 0. Title validation (strict mode — required for publish)
+  if (!title || title.trim() === '') {
+    errors.push({ code: 'MISSING_TITLE', message: 'Title is required for publishing', field: 'title' })
+  }
 
   // 1. Equipment validation
   errors.push(...validateEquipment(content.equipment))
@@ -868,72 +922,64 @@ export function validatePlannerForSave(
 }
 
 /**
- * User-friendly validation for publish/save operations
- * Returns i18n error details if validation fails, null if valid
+ * Non-strict validation for sync/draft-save operations
+ * Runs all structural checks but allows missing title and missing theme packs.
+ * Returns the first error as an i18n key+params, or null if valid.
  *
- * Checks:
- * 1. Title is not empty
- * 2. All floors have theme pack selected
- * 3. 10F/15F categories don't have Normal difficulty on floors 1-5
- * 4. Floor gifts are affordable for selected theme pack
+ * Mirrors BE relaxed mode: title and theme packs are optional; all other checks
+ * (equipment, deployment, skill EA, gift IDs, start buffs, start gifts,
+ * floor prerequisites, gift affordability) run identically to strict mode.
  *
- * @param title - Planner title
- * @param floorSelections - Floor selections with theme packs, difficulty, and gift IDs
- * @param category - MD category
+ * @param content - MD planner content to validate
+ * @param category - MD category (5F, 10F, or 15F)
  * @param egoGiftSpec - EGO Gift spec data (optional, skips affordability check if not provided)
  * @param egoGiftI18n - EGO Gift i18n names (optional, uses IDs if not provided)
  * @returns Object with i18n key and params, or null if valid
  */
 export function validatePlannerUserFriendly(
-  title: string | undefined,
-  floorSelections: { themePackId: string | null; difficulty: number; giftIds: Set<string> | string[] }[],
+  content: MDPlannerContent,
   category: MDCategory,
   egoGiftSpec?: Record<string, EGOGiftSpec>,
   egoGiftI18n?: Record<string, string>
 ): { key: string; params?: Record<string, string> } | null {
-  // Check title
-  if (!title || title.trim() === '') {
-    return { key: 'pages.plannerMD.publish.missingTitle' }
-  }
+  const errors: PlannerValidationError[] = []
 
-  // Check theme packs for all floors
+  // 1. Equipment validation
+  errors.push(...validateEquipment(content.equipment))
+
+  // 2. Deployment order validation
+  errors.push(...validateDeploymentOrder(content.deploymentOrder))
+
+  // 3. Skill EA state validation
+  errors.push(...validateSkillEAState(content.skillEAState))
+
+  // 4. Gift IDs validation (all three arrays)
+  errors.push(...validateGiftIdArray(content.selectedGiftIds, 'selectedGiftIds'))
+  errors.push(...validateGiftIdArray(content.observationGiftIds, 'observationGiftIds'))
+  errors.push(...validateGiftIdArray(content.comprehensiveGiftIds, 'comprehensiveGiftIds'))
+
+  // 5. Start buffs validation
+  errors.push(...validateStartBuffIds(content.selectedBuffIds))
+
+  // 6. Start gifts validation
+  errors.push(...validateStartGiftSelection(content.selectedGiftKeyword, content.selectedGiftIds))
+
+  // 7. Floor selections validation (non-strict: theme packs optional)
   const floorCount = FLOOR_COUNTS[category]
-  const hasAllThemePacks = floorSelections
-    .slice(0, floorCount)
-    .every((floor) => floor.themePackId !== null)
+  const deserializedFloorSelections: FloorThemeSelection[] = content.floorSelections.map(floor => ({
+    ...floor,
+    giftIds: new Set(floor.giftIds)
+  }))
+  const floorErrors = validateFloorThemePacksForSave(deserializedFloorSelections, floorCount)
+  // Filter out FLOOR_MISSING_THEME_PACK — theme packs are optional in non-strict mode.
+  // Prerequisites and duplicates still fire when a floor *does* have a pack.
+  errors.push(...floorErrors.filter(e => e.code !== 'FLOOR_MISSING_THEME_PACK'))
 
-  if (!hasAllThemePacks) {
-    return { key: 'pages.plannerMD.publish.missingThemePack' }
-  }
-
-  // Check difficulty for 10F/15F (floors 1-5 must not be Normal)
-  if (category !== '5F') {
-    const hasNormalDifficulty = floorSelections
-      .slice(0, 5)
-      .some((floor) => floor.difficulty === DUNGEON_IDX.NORMAL)
-
-    if (hasNormalDifficulty) {
-      return { key: 'pages.plannerMD.publish.requiresHardMode' }
-    }
-  }
-
-  // Check gift affordability (if egoGiftSpec is provided)
+  // 8. Gift affordability (validateFloorGiftAffordability already guards on themePackId being set)
   if (egoGiftSpec) {
-    for (let i = 0; i < floorCount; i++) {
-      const floor = floorSelections[i]
-      if (!floor?.themePackId) continue
-
-      const giftIds = floor.giftIds instanceof Set ? floor.giftIds : new Set(floor.giftIds)
-      const { names } = getUnaffordableGiftNames(giftIds, floor.themePackId, egoGiftSpec, egoGiftI18n ?? {})
-
-      if (names.length > 0) {
-        return {
-          key: 'pages.plannerMD.gifts.unaffordableWarning',
-          params: { floor: String(i + 1), gifts: names.join(', ') },
-        }
-      }
-    }
+    errors.push(...validateFloorGiftAffordability(deserializedFloorSelections, floorCount, egoGiftSpec, egoGiftI18n))
   }
 
-  return null
+  if (errors.length === 0) return null
+  return toUserFriendlyError(errors[0])
 }

--- a/static/i18n/CN/planner.json
+++ b/static/i18n/CN/planner.json
@@ -222,7 +222,8 @@
           "description": "发布即表示您同意将此计划上传到服务器并向所有用户公开。如果您不希望继续，请按取消按钮。",
           "confirm": "同意并发布",
           "cancel": "取消"
-        }
+        },
+        "themePackEgoGiftInconsistency": "在主题包 {{pack}} 中无法获取 E.G.O 礼物 {{gifts}}。请重置列表后重新设置。"
       },
       "conflict": {
         "title": "在其他设备上已修改",
@@ -260,6 +261,9 @@
         "deletedComment": "此评论已被删除。",
         "modified": "已编辑",
         "updatedAt": "{{date}}编辑"
+      },
+      "validation": {
+        "corruptedState": "计划数据似乎已损坏。请刷新页面后重试。"
       }
     },
     "plannerList": {

--- a/static/i18n/EN/planner.json
+++ b/static/i18n/EN/planner.json
@@ -223,7 +223,8 @@
           "description": "By publishing, you agree that this plan will be uploaded to the server and made public to all users. If you do not wish to proceed, please press the cancel button.",
           "confirm": "Agree and Publish",
           "cancel": "Cancel"
-        }
+        },
+        "themePackEgoGiftInconsistency": "E.G.O Gifts {{gifts}} cannot be obtained in theme pack {{pack}}. Please reset the list and set them again."
       },
       "conflict": {
         "title": "Changed on Another Device",
@@ -264,6 +265,9 @@
         "deletedComment": "This comment has been deleted.",
         "modified": "modified",
         "updatedAt": "updated {{date}}"
+      },
+      "validation": {
+        "corruptedState": "Planner data appears corrupted. Please refresh and try again."
       }
     },
     "plannerList": {

--- a/static/i18n/JP/planner.json
+++ b/static/i18n/JP/planner.json
@@ -223,7 +223,8 @@
           "description": "公開することにより、このプランがサーバーにアップロードされ、すべてのユーザーに公開されることに同意します。これを望まない場合は、キャンセルボタンを押してください。",
           "confirm": "同意して公開",
           "cancel": "キャンセル"
-        }
+        },
+        "themePackEgoGiftInconsistency": "テーマパック {{pack}} では E.G.O ギフト {{gifts}} を獲得できません。リストをリセットして再設定してください。"
       },
       "conflict": {
         "title": "別のデバイスで変更されました",
@@ -261,6 +262,9 @@
         "deletedComment": "このコメントは削除されました。",
         "modified": "編集済み",
         "updatedAt": "{{date}}に編集"
+      },
+      "validation": {
+        "corruptedState": "プランナーのデータが破損しているようです。ページを更新してもう一度お試しください。"
       }
     },
     "plannerList": {

--- a/static/i18n/KR/planner.json
+++ b/static/i18n/KR/planner.json
@@ -223,7 +223,8 @@
           "description": "게시함으로써 당신은 이 플랜이 서버에 업로드되고 모든 접속자에게 공개됨에 동의합니다. 만일 이를 원치 않으신다면 취소 버튼을 눌러주세요.",
           "confirm": "동의하고 게시",
           "cancel": "취소"
-        }
+        },
+        "themePackEgoGiftInconsistency": "테마팩 {{pack}}에서는 E.G.O 기프트 {{gifts}}를 획득할 수 없습니다. 해당 리스트를 초기화한 후 다시 설정해주세요"
       },
       "conflict": {
         "title": "다른 기기에서 변경되었습니다",
@@ -264,6 +265,9 @@
       },
       "editor": {
         "resetToInitial": "초기 설정으로 복원"
+      },
+      "validation": {
+        "corruptedState": "플래너 데이터가 손상된 것 같습니다. 새로고침 후 다시 시도해 주세요."
       }
     },
     "plannerList": {


### PR DESCRIPTION
- Add TitleValidationError and toUserFriendlyError helper to plannerHelpers
- validatePlannerForSave (strict): title + theme packs required, full difficulty enforced
- validatePlannerUserFriendly (non-strict): all structural checks, title/theme packs optional
- Wire strict validation to handlePublishToggle and handlePublishWithUpload
- Add two-tier validation in usePlannerSave: strict for published, non-strict for draft
- Add themePackEgoGiftInconsistency i18n key (EN/KR/JP/CN) and wire to FLOOR_UNAFFORDABLE_GIFT
- Add plannerHelpers.test.ts with 29 tests covering all validators and helpers