### PR TITLE
feat: validate planner content before conflict resolution sync

### DIFF
--- a/frontend/src/components/dialogs/BatchConflictDialog.tsx
+++ b/frontend/src/components/dialogs/BatchConflictDialog.tsx
@@ -46,6 +46,8 @@ export interface BatchConflictDialogProps {
   onResolve: (resolutions: ConflictResolution[]) => void
   /** Whether resolution is in progress */
   isResolving?: boolean
+  /** Validation error from last resolution attempt (i18n key + optional params) */
+  error?: { key: string; params?: Record<string, string> } | null
 }
 
 /**
@@ -90,6 +92,7 @@ export function BatchConflictDialog({
   conflicts,
   onResolve,
   isResolving = false,
+  error = null,
 }: BatchConflictDialogProps) {
   const { t } = useTranslation(['planner', 'common'])
 
@@ -276,7 +279,12 @@ export function BatchConflictDialog({
           })}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="flex-col items-stretch gap-2 sm:flex-col">
+          {error && (
+            <p className="text-sm text-destructive">
+              {t(error.key, { ns: 'planner', ...error.params })}
+            </p>
+          )}
           <Button onClick={handleResolveAll} disabled={isResolving}>
             {t('pages.plannerMD.batchConflict.resolveAll', 'Resolve All')}
           </Button>

--- a/frontend/src/components/plannerList/PersonalPlannerList.tsx
+++ b/frontend/src/components/plannerList/PersonalPlannerList.tsx
@@ -50,6 +50,7 @@ export function PersonalPlannerList({
     pendingConflicts,
     resolveConflicts,
     isResolvingConflicts,
+    conflictResolutionError,
   } = useMDUserPlannersData({
     category,
     page,
@@ -98,6 +99,7 @@ export function PersonalPlannerList({
         conflicts={pendingConflicts}
         onResolve={resolveConflicts}
         isResolving={isResolvingConflicts}
+        error={conflictResolutionError}
       />
 
       <ResponsiveCardGrid cardWidth={CARD_GRID.WIDTH.PLANNER}>

--- a/frontend/src/hooks/useMDUserPlannersData.ts
+++ b/frontend/src/hooks/useMDUserPlannersData.ts
@@ -18,8 +18,10 @@ import { usePlannerSaveAdapter } from './usePlannerSaveAdapter'
 import { usePlannerSyncAdapter } from './usePlannerSyncAdapter'
 import { useAuthQuery } from './useAuthQuery'
 import { useUserSettingsQuery } from './useUserSettings'
+import { useEGOGiftListData } from './useEGOGiftListData'
+import { validatePlannerUserFriendly, validatePlannerForSave, toUserFriendlyError } from '@/lib/plannerHelpers'
 
-import type { PlannerSummary, SaveablePlanner } from '@/types/PlannerTypes'
+import type { PlannerSummary, SaveablePlanner, MDPlannerContent } from '@/types/PlannerTypes'
 import type { ConflictItem, ConflictResolution } from '@/components/dialogs/BatchConflictDialog'
 import type { MDCategory } from '@/lib/constants'
 
@@ -75,6 +77,8 @@ export interface MDUserPlannersResult {
   resolveConflicts: (resolutions: ConflictResolution[]) => Promise<void>
   /** Whether conflict resolution is in progress */
   isResolvingConflicts: boolean
+  /** Validation or sync error from last conflict resolution attempt */
+  conflictResolutionError: { key: string; params?: Record<string, string> } | null
 }
 
 // ============================================================================
@@ -138,6 +142,10 @@ export function useMDUserPlannersData(
   // Conflict resolution state
   const [pendingConflicts, setPendingConflicts] = useState<ConflictItem[]>([])
   const [isResolvingConflicts, setIsResolvingConflicts] = useState(false)
+  const [conflictResolutionError, setConflictResolutionError] = useState<{ key: string; params?: Record<string, string> } | null>(null)
+
+  // EGO Gift spec for affordability validation in conflict resolution
+  const { spec: egoGiftSpec, i18n: egoGiftI18n } = useEGOGiftListData()
 
   // Query: Local planners only (fast initial render)
   const { data: allPlanners } = useSuspenseQuery(
@@ -290,6 +298,31 @@ export function useMDUserPlannersData(
   }, [allPlanners, category, search, page])
 
   /**
+   * Validate a local planner's content before syncing to server.
+   * Mirrors performSave: strict when published, non-strict otherwise.
+   * Throws a typed error if invalid, to be caught by resolveConflicts outer catch.
+   */
+  const validateBeforeSync = (planner: SaveablePlanner) => {
+    if (planner.config.type !== 'MIRROR_DUNGEON' || !egoGiftSpec) return
+    const content = planner.content as MDPlannerContent
+    const { category } = planner.config
+    const { title, published } = planner.metadata
+
+    let friendlyError: { key: string; params?: Record<string, string> } | null = null
+
+    if (published) {
+      const { isValid, errors } = validatePlannerForSave(title, content, category, egoGiftSpec, egoGiftI18n)
+      if (!isValid) friendlyError = toUserFriendlyError(errors[0])
+    } else {
+      friendlyError = validatePlannerUserFriendly(content, category, egoGiftSpec, egoGiftI18n)
+    }
+
+    if (friendlyError) {
+      throw Object.assign(new Error('validationFailed'), { code: 'validationFailed', friendlyError })
+    }
+  }
+
+  /**
    * Resolve batch conflicts based on user choices
    * Pattern: mirrors usePlannerSave.resolveConflict() but for multiple items
    */
@@ -297,64 +330,72 @@ export function useMDUserPlannersData(
     if (resolutions.length === 0) return
 
     setIsResolvingConflicts(true)
+    setConflictResolutionError(null)
 
     try {
       for (const resolution of resolutions) {
         const conflict = pendingConflicts.find((c) => c.id === resolution.id)
         if (!conflict) continue
 
-        try {
-          if (resolution.choice === 'overwrite') {
-            // Keep local draft, force push to server
-            await syncAdapter.syncToServer(conflict.localPlanner, true)
-            // Update local with saved status
-            const saved: SaveablePlanner = {
-              ...conflict.localPlanner,
-              metadata: {
-                ...conflict.localPlanner.metadata,
-                status: 'saved',
-                savedAt: new Date().toISOString(),
-              },
-            }
-            await saveAdapter.saveToLocal(saved)
-          } else if (resolution.choice === 'discard') {
-            // Use server version, discard local draft
-            await saveAdapter.saveToLocal(conflict.serverPlanner)
-          } else if (resolution.choice === 'both') {
-            // Keep both: create copy of local, then use server for original
-            const copyId = crypto.randomUUID()
-            const deviceId = await saveAdapter.getOrCreateDeviceId()
-            const copy: SaveablePlanner = {
-              ...conflict.localPlanner,
-              metadata: {
-                ...conflict.localPlanner.metadata,
-                id: copyId,
-                title: `${conflict.localPlanner.metadata.title} (Copy)`,
-                status: 'saved',
-                syncVersion: 1,
-                deviceId,
-                createdAt: new Date().toISOString(),
-                lastModifiedAt: new Date().toISOString(),
-                savedAt: new Date().toISOString(),
-              },
-            }
-            await saveAdapter.saveToLocal(copy)
-            await syncAdapter.syncToServer(copy)
-            // Use server version for original
-            await saveAdapter.saveToLocal(conflict.serverPlanner)
+        if (resolution.choice === 'overwrite') {
+          // Validate before syncing local draft to server
+          validateBeforeSync(conflict.localPlanner)
+          // Keep local draft, force push to server
+          await syncAdapter.syncToServer(conflict.localPlanner, true)
+          // Update local with saved status
+          const saved: SaveablePlanner = {
+            ...conflict.localPlanner,
+            metadata: {
+              ...conflict.localPlanner.metadata,
+              status: 'saved',
+              savedAt: new Date().toISOString(),
+            },
           }
-        } catch (error) {
-          console.error(`Failed to resolve conflict for ${resolution.id}:`, error)
+          await saveAdapter.saveToLocal(saved)
+        } else if (resolution.choice === 'discard') {
+          // Use server version, discard local draft
+          await saveAdapter.saveToLocal(conflict.serverPlanner)
+        } else if (resolution.choice === 'both') {
+          // Keep both: create copy of local, then use server for original
+          const copyId = crypto.randomUUID()
+          const deviceId = await saveAdapter.getOrCreateDeviceId()
+          const copy: SaveablePlanner = {
+            ...conflict.localPlanner,
+            metadata: {
+              ...conflict.localPlanner.metadata,
+              id: copyId,
+              title: `${conflict.localPlanner.metadata.title} (Copy)`,
+              status: 'saved',
+              syncVersion: 1,
+              deviceId,
+              createdAt: new Date().toISOString(),
+              lastModifiedAt: new Date().toISOString(),
+              savedAt: new Date().toISOString(),
+            },
+          }
+          // Validate copy before syncing (same content as localPlanner)
+          validateBeforeSync(copy)
+          await saveAdapter.saveToLocal(copy)
+          await syncAdapter.syncToServer(copy)
+          // Use server version for original
+          await saveAdapter.saveToLocal(conflict.serverPlanner)
         }
       }
 
-      // Clear conflicts and update cache directly (avoids re-suspension)
+      // Only clear conflicts after ALL resolutions succeed
       setPendingConflicts([])
       const updatedLocal = await saveAdapter.listLocal()
       queryClient.setQueryData(
         userPlannersQueryKeys.list(isAuthenticated),
         updatedLocal
       )
+    } catch (error) {
+      const e = error as { code?: string; friendlyError?: { key: string; params?: Record<string, string> } }
+      if (e.code === 'validationFailed' && e.friendlyError) {
+        setConflictResolutionError(e.friendlyError)
+      } else {
+        console.error('Conflict resolution failed:', error)
+      }
     } finally {
       setIsResolvingConflicts(false)
     }
@@ -368,6 +409,7 @@ export function useMDUserPlannersData(
     pendingConflicts,
     resolveConflicts,
     isResolvingConflicts,
+    conflictResolutionError,
   }
 }
 

--- a/frontend/src/hooks/usePlannerSave.ts
+++ b/frontend/src/hooks/usePlannerSave.ts
@@ -356,6 +356,19 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
   const { spec: egoGiftSpec, i18n: egoGiftI18n } = useEGOGiftListData()
 
   /**
+   * Throws a user-friendly validation error with i18n key and params.
+   * Used in both performSave and resolveConflict to surface validation failures.
+   */
+  const throwValidationError = (friendly: { key: string; params?: Record<string, string> }) => {
+    const errorMessage = JSON.stringify({ key: friendly.key, params: friendly.params })
+    const error = new Error(errorMessage)
+    ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).code = 'userFriendlyValidation'
+    ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nKey = friendly.key
+    ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nParams = friendly.params
+    throw error
+  }
+
+  /**
    * Core save logic for manual save
    * - Always saves to IndexedDB via SaveAdapter
    * - If authenticated AND syncEnabled, also syncs to server via SyncAdapter
@@ -390,15 +403,6 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
 
     // Two-tier validation for MD planners (non-strict for draft, strict for published)
     if (plannerType === 'MIRROR_DUNGEON') {
-      const throwValidationError = (friendly: { key: string; params?: Record<string, string> }) => {
-        const errorMessage = JSON.stringify({ key: friendly.key, params: friendly.params })
-        const error = new Error(errorMessage)
-        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).code = 'userFriendlyValidation'
-        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nKey = friendly.key
-        ;(error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }).i18nParams = friendly.params
-        throw error
-      }
-
       const content = saveable.content as MDPlannerContent
 
       if (isCurrentlyPublished) {
@@ -658,6 +662,13 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
           false, // new copy is not published
           'saved' // mark as saved since we're syncing immediately
         )
+
+        // Validate copy content before saving/syncing (same content as currentState)
+        if (plannerType === 'MIRROR_DUNGEON' && egoGiftSpec) {
+          const content = newPlanner.content as MDPlannerContent
+          const validationError = validatePlannerUserFriendly(content, currentState.category, egoGiftSpec, egoGiftI18n)
+          if (validationError) throwValidationError(validationError)
+        }
 
         // Track whether copy was saved for cleanup on failure
         let copySavedToLocal = false


### PR DESCRIPTION
Run gift affordability validation before every syncToServer call in conflict resolution paths. Previously, the 'both' branch in resolveConflict and all three syncToServer calls in resolveConflicts bypassed validation, allowing GIFT_NOT_AFFORDABLE to reach the server.

- Extract throwValidationError to hook scope in usePlannerSave
- Validate 'both' branch copy before local save and server sync
- Add validateBeforeSync helper in useMDUserPlannersData (strict when published, non-strict otherwise, matching performSave semantics)
- Remove inner try-catch in resolveConflicts so errors propagate and setPendingConflicts([]) only runs on full success
- Surface validation errors in BatchConflictDialog footer