### PR TITLE
fix: remove deviceId from published planner detail response

### DIFF
--- a/backend/src/main/java/org/danteplanner/backend/dto/planner/PublishedPlannerDetailResponse.java
+++ b/backend/src/main/java/org/danteplanner/backend/dto/planner/PublishedPlannerDetailResponse.java
@@ -39,7 +39,6 @@ public class PublishedPlannerDetailResponse {
     private Integer contentVersion;
     private String status;
     private Long syncVersion;
-    private String deviceId;
 
     // Subscription and report status
     private Boolean isSubscribed;
@@ -106,7 +105,6 @@ public class PublishedPlannerDetailResponse {
                 .contentVersion(planner.getContentVersion())
                 .status(planner.getStatus())
                 .syncVersion(planner.getSyncVersion())
-                .deviceId(planner.getDeviceId())
                 .isSubscribed(isSubscribed)
                 .hasReported(hasReported)
                 .commentCount(commentCount)

--- a/frontend/src/hooks/usePublishedPlannerQuery.ts
+++ b/frontend/src/hooks/usePublishedPlannerQuery.ts
@@ -73,7 +73,7 @@ export async function fetchPublishedPlanner(plannerId: string): Promise<Publishe
     lastModifiedAt: apiData.lastModifiedAt ?? apiData.createdAt,
     savedAt: apiData.createdAt,
     userId: null,
-    deviceId: apiData.deviceId ?? 'published',
+    deviceId: 'published',
     published: true,
   }
 

--- a/frontend/src/schemas/PlannerListSchemas.ts
+++ b/frontend/src/schemas/PlannerListSchemas.ts
@@ -142,8 +142,6 @@ export const PublishedPlannerDetailSchema = PublicPlannerSchema.extend({
   status: PlannerStatusSchema,
   /** Server sync version for optimistic locking */
   syncVersion: z.number().int().positive(),
-  /** Device identifier (optional) */
-  deviceId: z.string().optional(),
   /** Subscription status for authenticated users (null if not authenticated) */
   isSubscribed: z.boolean().nullable(),
   /** Report status for authenticated users (null if not authenticated) */

--- a/frontend/src/types/PlannerListTypes.ts
+++ b/frontend/src/types/PlannerListTypes.ts
@@ -182,8 +182,6 @@ export interface PublishedPlannerDetail extends PublicPlanner {
   status: PlannerStatus
   /** Server sync version for optimistic locking */
   syncVersion: number
-  /** Device identifier (optional) */
-  deviceId?: string
   /** Subscription status for authenticated users (null if not authenticated) */
   isSubscribed: boolean | null
   /** Report status for authenticated users (null if not authenticated) */


### PR DESCRIPTION
deviceId was exposed in PublishedPlannerDetailResponse, allowing any visitor to correlate plans from the same device. The field is unused by any business logic — SSE exclusion uses the live request cookie, not the stored value. Frontend now uses the static string 'published' for local storage namespacing of viewed plans.