### PR TITLE
fix: inform user that conflict copy will not be published

### DIFF
--- a/frontend/src/components/dialogs/BatchConflictDialog.tsx
+++ b/frontend/src/components/dialogs/BatchConflictDialog.tsx
@@ -256,6 +256,12 @@ export function BatchConflictDialog({
                   {' | '}
                   {t('pages.plannerMD.batchConflict.serverModified', 'Server')}: {formatDate(conflict.serverPlanner.metadata.lastModifiedAt)}
                 </p>
+                {/* Notification that copy won't be published */}
+                {conflict.localPlanner.metadata.published && (
+                  <p className="text-xs text-muted-foreground">
+                    {t('pages.plannerMD.conflict.keepBothUnpublished', 'The copy will not be published')}
+                  </p>
+                )}
                 {/* Buttons */}
                 <div className="flex gap-1">
                   <ChoiceButton

--- a/frontend/src/components/planner/ConflictResolutionDialog.tsx
+++ b/frontend/src/components/planner/ConflictResolutionDialog.tsx
@@ -124,6 +124,12 @@ export function ConflictResolutionDialog({
           </div>
         )}
 
+        {(localPlanner?.metadata.published || serverPlanner?.metadata.published) && (
+          <p className="text-xs text-muted-foreground">
+            {t('pages.plannerMD.conflict.keepBothUnpublished', 'The copy will not be published')}
+          </p>
+        )}
+
         <DialogFooter className="flex-col gap-2 sm:flex-row">
           <Button
             variant="outline"

--- a/static/i18n/CN/planner.json
+++ b/static/i18n/CN/planner.json
@@ -237,7 +237,8 @@
         "copySuffix": "{{title}} (副本)",
         "overwriteSuccess": "更改已保存到服务器",
         "discardSuccess": "已加载服务器版本",
-        "keepBothSuccess": "副本已创建"
+        "keepBothSuccess": "副本已创建",
+        "keepBothUnpublished": "副本不会被公开"
       },
       "batchConflict": {
         "title": "在其他设备上已修改",

--- a/static/i18n/EN/planner.json
+++ b/static/i18n/EN/planner.json
@@ -238,7 +238,8 @@
         "copySuffix": "{{title}} (Copy)",
         "overwriteSuccess": "Server updated with your changes",
         "discardSuccess": "Server version loaded",
-        "keepBothSuccess": "Copy created successfully"
+        "keepBothSuccess": "Copy created successfully",
+        "keepBothUnpublished": "The copy will not be published"
       },
       "batchConflict": {
         "title": "Changed on Another Device",

--- a/static/i18n/JP/planner.json
+++ b/static/i18n/JP/planner.json
@@ -238,7 +238,8 @@
         "copySuffix": "{{title}} (コピー)",
         "overwriteSuccess": "変更がサーバーに保存されました",
         "discardSuccess": "サーバーバージョンを読み込みました",
-        "keepBothSuccess": "コピーが作成されました"
+        "keepBothSuccess": "コピーが作成されました",
+        "keepBothUnpublished": "コピーは公開されません"
       },
       "batchConflict": {
         "title": "別のデバイスで変更されました",

--- a/static/i18n/KR/planner.json
+++ b/static/i18n/KR/planner.json
@@ -238,7 +238,8 @@
         "copySuffix": "{{title}} (복사본)",
         "overwriteSuccess": "변경사항이 서버에 저장되었습니다",
         "discardSuccess": "서버 버전을 불러왔습니다",
-        "keepBothSuccess": "복사본이 생성되었습니다"
+        "keepBothSuccess": "복사본이 생성되었습니다",
+        "keepBothUnpublished": "복사본은 공개되지 않습니다"
       },
       "batchConflict": {
         "title": "다른 기기에서 변경되었습니다",


### PR DESCRIPTION
The conflict resolution dialog offers a "Save as Copy" option that forks local changes into a new planner. When the original planner is published, nothing in the UI indicated the copy would not inherit that status.

Prior to this commit, users resolving a conflict via "Save as Copy" on a published planner had no way to know the resulting copy would be unpublished, which was unexpected and potentially confusing.

This commit adds a contextual note in both the single and batch conflict dialogs, shown only when the planner is published, with translations for EN, KR, JP, and CN.