### PR TITLE
fix: invalidate published planner cache after save

### DIFF
--- a/frontend/src/routes/PlannerMDEditorContent.tsx
+++ b/frontend/src/routes/PlannerMDEditorContent.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, Suspense, startTransition, useCallback, useRef } f
 import { useNavigate } from '@tanstack/react-router'
 import { queryClient } from '@/lib/queryClient'
 import { plannerQueryKeys } from '@/hooks/useSavedPlannerQuery'
+import { publishedPlannerQueryKeys } from '@/hooks/usePublishedPlannerQuery'
 
 // Third-party libraries
 import { useTranslation } from 'react-i18next'
@@ -487,6 +488,7 @@ export function PlannerMDEditorContent({ mode, planner }: PlannerMDEditorContent
       toast.success(t('pages.plannerMD.save.success'))
       queryClient.removeQueries({ queryKey: plannerQueryKeys.detail(plannerId) })
       if (isPublished) {
+        queryClient.removeQueries({ queryKey: publishedPlannerQueryKeys.detail(plannerId) })
         void navigate({ to: '/planner/md/gesellschaft/$id', params: { id: plannerId } })
       } else {
         void navigate({ to: '/planner/md/$id', params: { id: plannerId } })


### PR DESCRIPTION
Saving a published planner did not remove the ['publishedPlanner', id] TanStack Query cache entry, so navigating to /planner/md/gesellschaft/{id} served the stale 5-minute cached response instead of the freshly saved data.