### PR TITLE
chore: generate .my.cnf inside MySQL container on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   mysql:
-    image: mysql:8.0
+    build:
+      context: ./mysql
+    image: danteplanner-mysql:local
     container_name: danteplanner-mysql
     restart: unless-stopped
     environment:

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,7 @@
+FROM mysql:8.0
+
+COPY entrypoint.sh /entrypoint-wrapper.sh
+RUN chmod +x /entrypoint-wrapper.sh
+
+ENTRYPOINT ["/entrypoint-wrapper.sh"]
+CMD ["mysqld"]

--- a/mysql/entrypoint.sh
+++ b/mysql/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+printf '[client]\nuser=%s\npassword=%s\nhost=localhost\n' \
+  "${MYSQL_USER}" "${MYSQL_PASSWORD}" > /root/.my.cnf
+chmod 600 /root/.my.cnf
+
+exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
Wraps the official mysql:8.0 entrypoint to write /root/.my.cnf from MYSQL_USER and MYSQL_PASSWORD env vars, enabling credential-free docker exec access without storing credentials on the host.