### PR TITLE
fix: local planner persists after delete, stale list, and upsert crash

### DIFF
--- a/backend/src/main/java/org/danteplanner/backend/controller/PlannerController.java
+++ b/backend/src/main/java/org/danteplanner/backend/controller/PlannerController.java
@@ -169,7 +169,7 @@ public class PlannerController {
         log.info("Upserting planner {} for user {}, force={}", id, userId, force);
         UpsertResult result = plannerService.upsertPlanner(userId, deviceId, id, request, force);
 
-        HttpStatus status = result.created() ? HttpStatus.CREATED : HttpStatus.OK;
+        HttpStatus status = result.isCreated() ? HttpStatus.CREATED : HttpStatus.OK;
         return ResponseEntity.status(status).body(result.response());
     }
 

--- a/backend/src/main/java/org/danteplanner/backend/dto/planner/UpsertResult.java
+++ b/backend/src/main/java/org/danteplanner/backend/dto/planner/UpsertResult.java
@@ -9,7 +9,7 @@ package org.danteplanner.backend.dto.planner;
  *
  * <p>Not exposed in API - controller extracts response for client.
  */
-public record UpsertResult(PlannerResponse response, boolean created) {
+public record UpsertResult(PlannerResponse response, boolean isCreated) {
 
     /**
      * Create result for a newly created planner.

--- a/backend/src/main/java/org/danteplanner/backend/repository/PlannerRepository.java
+++ b/backend/src/main/java/org/danteplanner/backend/repository/PlannerRepository.java
@@ -47,6 +47,12 @@ public interface PlannerRepository extends JpaRepository<Planner, UUID> {
      */
     boolean existsByIdAndDeletedAtIsNull(UUID id);
 
+    /**
+     * Check if a planner exists by ID and user ID, regardless of soft-delete state.
+     * Used to detect soft-deleted planners before attempting recreation in upsert.
+     */
+    boolean existsByIdAndUserId(UUID id, Long userId);
+
     // ==================== Published Planner Queries ====================
 
     /**

--- a/backend/src/main/java/org/danteplanner/backend/service/PlannerService.java
+++ b/backend/src/main/java/org/danteplanner/backend/service/PlannerService.java
@@ -307,6 +307,12 @@ public class PlannerService {
             return UpsertResult.updated(PlannerResponse.fromEntity(saved));
         }
 
+        // Check if user's own planner was soft-deleted (prevents PRIMARY KEY collision)
+        if (plannerRepository.existsByIdAndUserId(id, userId)) {
+            log.warn("Planner {} is soft-deleted for user {} - cannot recreate", id, userId);
+            throw new PlannerNotFoundException(id);
+        }
+
         // Check if planner exists for another user (prevents ID collision)
         if (plannerRepository.existsByIdAndDeletedAtIsNull(id)) {
             log.warn("Planner {} exists but belongs to another user (ID collision)", id);

--- a/backend/src/test/java/org/danteplanner/backend/service/PlannerServiceTest.java
+++ b/backend/src/test/java/org/danteplanner/backend/service/PlannerServiceTest.java
@@ -1598,4 +1598,70 @@ class PlannerServiceTest {
             verify(plannerRepository).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("Upsert Soft-Delete Guard Tests")
+    class UpsertSoftDeleteGuardTests {
+
+        private UpsertPlannerRequest buildRequest() {
+            UpsertPlannerRequest request = new UpsertPlannerRequest();
+            request.setTitle("Test Planner");
+            request.setPlannerType(PlannerType.MIRROR_DUNGEON);
+            request.setCategory("5F");
+            request.setContent("{}");
+            request.setContentVersion(1);
+            return request;
+        }
+
+        @Test
+        @DisplayName("Should throw PlannerNotFoundException when user's own planner is soft-deleted")
+        void upsertPlanner_softDeletedByUser_throwsPlannerNotFoundException() {
+            // Arrange
+            UUID plannerId = UUID.randomUUID();
+            UpsertPlannerRequest request = buildRequest();
+
+            when(plannerRepository.findByIdAndUserIdAndDeletedAtIsNull(plannerId, testUser.getId()))
+                    .thenReturn(Optional.empty());
+            when(plannerRepository.existsByIdAndUserId(plannerId, testUser.getId()))
+                    .thenReturn(true);
+
+            // Act & Assert
+            assertThrows(
+                    PlannerNotFoundException.class,
+                    () -> plannerService.upsertPlanner(testUser.getId(), deviceId, plannerId, request, false)
+            );
+            verify(plannerRepository, never()).save(any());
+            verify(plannerRepository, never()).countByUserIdAndDeletedAtIsNull(any());
+        }
+
+        @Test
+        @DisplayName("Should proceed to create when planner UUID is genuinely new")
+        void upsertPlanner_genuinelyNewUUID_proceeds() {
+            // Arrange
+            UUID plannerId = UUID.randomUUID();
+            UpsertPlannerRequest request = buildRequest();
+
+            when(plannerRepository.findByIdAndUserIdAndDeletedAtIsNull(plannerId, testUser.getId()))
+                    .thenReturn(Optional.empty());
+            when(plannerRepository.existsByIdAndUserId(plannerId, testUser.getId()))
+                    .thenReturn(false);
+            when(plannerRepository.existsByIdAndDeletedAtIsNull(plannerId))
+                    .thenReturn(false);
+            when(userRepository.findById(testUser.getId()))
+                    .thenReturn(Optional.of(testUser));
+            when(plannerRepository.countByUserIdAndDeletedAtIsNull(testUser.getId()))
+                    .thenReturn(0L);
+            when(plannerRepository.save(any(Planner.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            UpsertResult result = plannerService.upsertPlanner(
+                    testUser.getId(), deviceId, plannerId, request, false);
+
+            // Assert
+            assertNotNull(result);
+            assertTrue(result.isCreated());
+            verify(plannerRepository).save(any());
+        }
+    }
 }

--- a/frontend/src/components/plannerViewer/PlannerDetailHeader.test.tsx
+++ b/frontend/src/components/plannerViewer/PlannerDetailHeader.test.tsx
@@ -3,11 +3,13 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import { PlannerDetailHeader } from './PlannerDetailHeader'
+import { NotFoundError } from '@/lib/api'
 import type { SaveablePlanner, MDPlannerContent } from '@/types/PlannerTypes'
 
 // ── Router ────────────────────────────────────────────────────
+const mockNavigate = vi.fn()
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
 }))
 
 // ── i18n ─────────────────────────────────────────────────────
@@ -31,6 +33,7 @@ vi.mock('sonner', () => ({
 vi.mock('@/lib/api', () => ({
   BannedError: class BannedError extends Error {},
   TimedOutError: class TimedOutError extends Error {},
+  NotFoundError: class NotFoundError extends Error {},
 }))
 
 // ── Child dialogs ─────────────────────────────────────────────
@@ -51,9 +54,15 @@ vi.mock('./ApplyLatestMirrorDialog', () => ({
     ) : null,
 }))
 vi.mock('./CopyUrlButton', () => ({ CopyUrlButton: () => null }))
-vi.mock('./DeleteConfirmDialog', () => ({ DeleteConfirmDialog: () => null }))
+vi.mock('./DeleteConfirmDialog', () => ({
+  DeleteConfirmDialog: ({ open, onConfirm }: { open: boolean; onConfirm: () => void }) =>
+    open ? <button data-testid="confirm-delete" onClick={onConfirm}>Confirm Delete</button> : null,
+}))
 vi.mock('./ModeratorDeleteDialog', () => ({ ModeratorDeleteDialog: () => null }))
-vi.mock('./PublishSyncOffWarningDialog', () => ({ PublishSyncOffWarningDialog: () => null }))
+vi.mock('./PublishSyncOffWarningDialog', () => ({
+  PublishSyncOffWarningDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="publish-sync-warning" /> : null,
+}))
 
 // ── Auth ──────────────────────────────────────────────────────
 vi.mock('@/hooks/useAuthQuery', () => ({
@@ -64,8 +73,9 @@ vi.mock('@/hooks/useAuthQuery', () => ({
 
 // ── Storage ───────────────────────────────────────────────────
 const mockSavePlanner = vi.fn().mockResolvedValue({ success: true })
+const mockDeletePlanner = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/hooks/usePlannerStorage', () => ({
-  usePlannerStorage: () => ({ savePlanner: mockSavePlanner }),
+  usePlannerStorage: () => ({ savePlanner: mockSavePlanner, deletePlanner: mockDeletePlanner }),
 }))
 
 // ── Sync adapter ──────────────────────────────────────────────
@@ -89,14 +99,23 @@ vi.mock('@/hooks/usePlannerConfig', () => ({
 vi.mock('@/hooks/usePlannerSubscription', () => ({
   usePlannerSubscription: () => ({ mutate: vi.fn(), isPending: false }),
 }))
+const mockDeleteMutate = vi.fn()
 vi.mock('@/hooks/usePlannerDelete', () => ({
-  usePlannerDelete: () => ({ mutate: vi.fn(), isPending: false }),
+  usePlannerDelete: () => ({ mutate: mockDeleteMutate, isPending: false }),
 }))
 vi.mock('@/hooks/useModeratorPlannerDelete', () => ({
   useModeratorPlannerDelete: () => ({ mutate: vi.fn(), isPending: false }),
 }))
+const mockPublishMutate = vi.fn()
 vi.mock('@/hooks/usePlannerPublish', () => ({
-  usePlannerPublish: () => ({ mutate: vi.fn(), isPending: false }),
+  usePlannerPublish: () => ({ mutate: mockPublishMutate, isPending: false }),
+}))
+
+// ── Planner helpers (validation) ──────────────────────────────
+vi.mock('@/lib/plannerHelpers', () => ({
+  validatePlannerForSave: () => ({ isValid: true, errors: [] }),
+  validatePlannerUserFriendly: () => null,
+  toUserFriendlyError: (e: unknown) => ({ key: 'error.key', params: {} }),
 }))
 vi.mock('@/hooks/usePlannerOwnerNotifications', () => ({
   useToggleOwnerNotifications: () => ({ mutate: vi.fn(), isPending: false }),
@@ -365,6 +384,182 @@ describe('PlannerDetailHeader – Apply Latest Mirror', () => {
           })
         )
       })
+    })
+  })
+})
+
+// ────────────────────────────────────────────────────────────────
+// Delete with local cleanup tests
+// ────────────────────────────────────────────────────────────────
+
+describe('PlannerDetailHeader – delete with local cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeletePlanner.mockResolvedValue(undefined)
+  })
+
+  async function openAndConfirmDelete() {
+    fireEvent.click(screen.getByText('pages.plannerList.contextMenu.delete'))
+    fireEvent.click(await screen.findByTestId('confirm-delete'))
+  }
+
+  it('calls deletePlanner locally on successful server delete', async () => {
+    mockDeleteMutate.mockImplementation(
+      (_id: string, callbacks?: { onSuccess?: () => void }) => {
+        callbacks?.onSuccess?.()
+      }
+    )
+
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner()}
+        isOwner={true}
+        isAuthenticated={true}
+      />,
+      { wrapper }
+    )
+
+    await openAndConfirmDelete()
+
+    await waitFor(() => {
+      expect(mockDeletePlanner).toHaveBeenCalledWith(PLANNER_ID)
+    })
+  })
+
+  it('calls deletePlanner locally and navigates when server returns 404', async () => {
+    mockDeleteMutate.mockImplementation(
+      (_id: string, callbacks?: { onError?: (e: Error) => void }) => {
+        callbacks?.onError?.(new NotFoundError('not found'))
+      }
+    )
+
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner()}
+        isOwner={true}
+        isAuthenticated={true}
+      />,
+      { wrapper }
+    )
+
+    await openAndConfirmDelete()
+
+    await waitFor(() => {
+      expect(mockDeletePlanner).toHaveBeenCalledWith(PLANNER_ID)
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ to: '/planner/md' })
+      )
+    })
+  })
+
+  it('does not delete locally or navigate on non-404 server errors', async () => {
+    mockDeleteMutate.mockImplementation(
+      (_id: string, callbacks?: { onError?: (e: Error) => void }) => {
+        callbacks?.onError?.(new Error('Internal server error'))
+      }
+    )
+
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner()}
+        isOwner={true}
+        isAuthenticated={true}
+      />,
+      { wrapper }
+    )
+
+    await openAndConfirmDelete()
+
+    await waitFor(() => {
+      expect(mockDeletePlanner).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ────────────────────────────────────────────────────────────────
+// Publish sync guard tests
+// ────────────────────────────────────────────────────────────────
+
+describe('PlannerDetailHeader – publish sync guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPublishMutate.mockImplementation(vi.fn())
+  })
+
+  function clickPublishButton() {
+    fireEvent.click(screen.getByText('pages.plannerMD.publish.button'))
+  }
+
+  it('shows sync-off warning when syncEnabled is null (not configured)', async () => {
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner({ published: false })}
+        isOwner={true}
+        isAuthenticated={true}
+        syncEnabled={null}
+      />,
+      { wrapper }
+    )
+
+    clickPublishButton()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('publish-sync-warning')).toBeDefined()
+      expect(mockPublishMutate).not.toHaveBeenCalled()
+    })
+  })
+
+  it('shows sync-off warning when syncEnabled is false', async () => {
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner({ published: false })}
+        isOwner={true}
+        isAuthenticated={true}
+        syncEnabled={false}
+      />,
+      { wrapper }
+    )
+
+    clickPublishButton()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('publish-sync-warning')).toBeDefined()
+      expect(mockPublishMutate).not.toHaveBeenCalled()
+    })
+  })
+
+  it('calls publishMutation directly when syncEnabled is true', async () => {
+    const { wrapper } = createWrapper()
+    render(
+      <PlannerDetailHeader
+        variant="personal"
+        planner={makePlanner({ published: false })}
+        isOwner={true}
+        isAuthenticated={true}
+        syncEnabled={true}
+      />,
+      { wrapper }
+    )
+
+    clickPublishButton()
+
+    await waitFor(() => {
+      expect(mockPublishMutate).toHaveBeenCalledWith(
+        PLANNER_ID,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      )
+      expect(screen.queryByTestId('publish-sync-warning')).toBeNull()
     })
   })
 })

--- a/frontend/src/components/plannerViewer/PlannerDetailHeader.tsx
+++ b/frontend/src/components/plannerViewer/PlannerDetailHeader.tsx
@@ -17,7 +17,7 @@ import {
 
 import { toast } from 'sonner'
 
-import { BannedError, TimedOutError } from '@/lib/api'
+import { BannedError, NotFoundError, TimedOutError } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { ApplyLatestMirrorDialog } from './ApplyLatestMirrorDialog'
@@ -36,6 +36,7 @@ import { usePlannerConfig } from '@/hooks/usePlannerConfig'
 import { usePlannerStorage } from '@/hooks/usePlannerStorage'
 import { plannerQueryKeys } from '@/hooks/useSavedPlannerQuery'
 import { publishedPlannerQueryKeys } from '@/hooks/usePublishedPlannerQuery'
+import { userPlannersQueryKeys } from '@/hooks/useMDUserPlannersData'
 import { useEGOGiftListData } from '@/hooks/useEGOGiftListData'
 import { usePlannerSyncAdapter } from '@/hooks/usePlannerSyncAdapter'
 import { useQueryClient } from '@tanstack/react-query'
@@ -122,7 +123,7 @@ export function PlannerDetailHeader({
   const moderatorDeleteMutation = useModeratorPlannerDelete()
   const publishMutation = usePlannerPublish()
   const ownerNotificationMutation = useToggleOwnerNotifications()
-  const { savePlanner } = usePlannerStorage()
+  const { savePlanner, deletePlanner } = usePlannerStorage()
   const syncAdapter = usePlannerSyncAdapter()
   const queryClient = useQueryClient()
   const { spec: egoGiftSpec, i18n: egoGiftI18n } = useEGOGiftListData()
@@ -158,17 +159,26 @@ export function PlannerDetailHeader({
   const handleDeleteConfirm = () => {
     if (onDelete) {
       onDelete()
-    } else if (plannerId) {
-      deleteMutation.mutate(plannerId, {
-        onSuccess: () => {
-          // Close dialog first, then navigate after animation completes
-          setShowDeleteDialog(false)
-          setTimeout(() => {
-            void navigate({ to: isPublished ? '/planner/md/gesellschaft' : '/planner/md' })
-          }, 150)
-        },
-      })
+      return
     }
+    if (!plannerId) return
+
+    const cleanup = () => {
+      void deletePlanner(plannerId)
+      void queryClient.invalidateQueries({ queryKey: userPlannersQueryKeys.all })
+      setShowDeleteDialog(false)
+      setTimeout(() => {
+        void navigate({ to: isPublished ? '/planner/md/gesellschaft' : '/planner/md' })
+      }, 150)
+    }
+
+    deleteMutation.mutate(plannerId, {
+      onSuccess: cleanup,
+      onError: (error) => {
+        // Planner not on server (local-only or already deleted) — still clean up locally
+        if (error instanceof NotFoundError) cleanup()
+      },
+    })
   }
 
   const handleModeratorDeleteConfirm = (reason: string) => {
@@ -264,8 +274,8 @@ export function PlannerDetailHeader({
       }
     }
 
-    // Check if sync is disabled and user is trying to publish (not unpublish)
-    if (syncEnabled === false && !savedPlanner.metadata.published) {
+    // Check if sync is not enabled and user is trying to publish (not unpublish)
+    if (syncEnabled !== true && !savedPlanner.metadata.published) {
       // Show warning dialog for sync-off publish
       setShowPublishWarning(true)
       return

--- a/frontend/src/hooks/usePlannerDelete.test.tsx
+++ b/frontend/src/hooks/usePlannerDelete.test.tsx
@@ -11,7 +11,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { usePlannerDelete } from './usePlannerDelete'
 import { gesellschaftQueryKeys } from './useMDGesellschaftData'
-import { userPlannersQueryKeys } from './useMDUserPlannersData'
 
 // Mock the API client
 vi.mock('@/lib/api', () => ({
@@ -87,7 +86,7 @@ describe('usePlannerDelete', () => {
   })
 
   describe('cache invalidation', () => {
-    it('invalidates both gesellschaft and user planner queries on success', async () => {
+    it('invalidates gesellschaft queries on success', async () => {
       vi.mocked(ApiClient.delete).mockResolvedValue(undefined)
       const { wrapper, queryClient } = createWrapper()
 
@@ -102,12 +101,6 @@ describe('usePlannerDelete', () => {
       await waitFor(() => {
         expect(invalidateSpy).toHaveBeenCalledWith({
           queryKey: gesellschaftQueryKeys.all,
-        })
-      })
-
-      await waitFor(() => {
-        expect(invalidateSpy).toHaveBeenCalledWith({
-          queryKey: userPlannersQueryKeys.all,
         })
       })
     })

--- a/frontend/src/hooks/usePlannerDelete.ts
+++ b/frontend/src/hooks/usePlannerDelete.ts
@@ -13,7 +13,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { ApiClient } from '@/lib/api'
 import { gesellschaftQueryKeys } from './useMDGesellschaftData'
-import { userPlannersQueryKeys } from './useMDUserPlannersData'
 
 // ============================================================================
 // Main Hook
@@ -54,9 +53,8 @@ export function usePlannerDelete() {
       // 204 No Content - no response body needed
     },
     onSuccess: () => {
-      // Invalidate all planner list queries (both community and personal)
+      // Invalidate community list (server-side concern)
       void queryClient.invalidateQueries({ queryKey: gesellschaftQueryKeys.all })
-      void queryClient.invalidateQueries({ queryKey: userPlannersQueryKeys.all })
     },
     onError: (error) => {
       console.error('Delete failed:', error)


### PR DESCRIPTION
Planner sync depends on local IndexedDB and the server staying in agreement. Several flows assumed the server's state matched what the client held locally.

Prior to this commit, syncing a locally-held planner that had been soft-deleted on the server caused a PRIMARY KEY constraint violation because the upsert path attempted an INSERT rather than detecting the existing deleted row. Separately, the publish guard checked syncEnabled === false but not null, silently proceeding when the user had never configured sync. On delete, the planner was only removed from the server but not from local IndexedDB, leaving it reappear after a refresh. The 404 path also never invalidated the planner list cache, leaving the deleted planner visible until the 30-second stale window expired.

This commit guards the upsert path against soft-deleted duplicates, tightens the publish guard to treat unconfigured sync identically to disabled, and extracts a shared post-delete cleanup that removes the planner from IndexedDB and invalidates the list cache on both server success and 404 outcomes.