### PR TITLE
feat: show comment count on published plan list cards

### DIFF
--- a/backend/src/main/java/org/danteplanner/backend/dto/planner/PublicPlannerResponse.java
+++ b/backend/src/main/java/org/danteplanner/backend/dto/planner/PublicPlannerResponse.java
@@ -52,6 +52,11 @@ public class PublicPlannerResponse {
     private Boolean isBookmarked;
 
     /**
+     * Total non-deleted comment count for this planner.
+     */
+    private Long commentCount;
+
+    /**
      * Create a PublicPlannerResponse from a Planner entity.
      *
      * <p>Author username is extracted from the planner's user entity.

--- a/backend/src/main/java/org/danteplanner/backend/repository/PlannerCommentRepository.java
+++ b/backend/src/main/java/org/danteplanner/backend/repository/PlannerCommentRepository.java
@@ -77,6 +77,21 @@ public interface PlannerCommentRepository extends JpaRepository<PlannerComment, 
     long countByPlannerIdAndDeletedAtIsNull(UUID plannerId);
 
     /**
+     * Batch count non-deleted comments grouped by planner ID.
+     * Used for list views to avoid N+1 queries when displaying comment counts.
+     *
+     * @param plannerIds list of planner IDs to count comments for
+     * @return list of [plannerId, count] pairs
+     */
+    @Query("""
+        SELECT c.plannerId, COUNT(c)
+        FROM PlannerComment c
+        WHERE c.plannerId IN :plannerIds AND c.deletedAt IS NULL
+        GROUP BY c.plannerId
+        """)
+    List<Object[]> countByPlannerIdsGrouped(@Param("plannerIds") List<UUID> plannerIds);
+
+    /**
      * Find a comment by its public UUID.
      * Used for resolving frontend UUIDs to internal entities.
      *

--- a/backend/src/main/java/org/danteplanner/backend/service/PlannerService.java
+++ b/backend/src/main/java/org/danteplanner/backend/service/PlannerService.java
@@ -861,7 +861,7 @@ public class PlannerService {
     }
 
     /**
-     * Map planners to responses with user context (votes and bookmarks).
+     * Map planners to responses with user context (votes, bookmarks, and comment counts).
      * Uses batch queries to prevent N+1 query issues.
      *
      * @param planners the page of planners
@@ -869,15 +869,20 @@ public class PlannerService {
      * @return page of public planner responses with user context
      */
     private Page<PublicPlannerResponse> mapPlannersWithUserContext(Page<Planner> planners, Long userId) {
-        if (userId == null) {
-            // Anonymous user - no vote/bookmark context needed
-            return planners.map(PublicPlannerResponse::fromEntity);
-        }
-
-        // Batch fetch all votes and bookmarks for this user and page of planners
+        // Batch fetch comment counts for all planners on this page (guest and authenticated)
         List<UUID> plannerIds = planners.getContent().stream()
                 .map(Planner::getId)
                 .collect(Collectors.toList());
+        Map<UUID, Long> commentCountMap = batchFetchCommentCounts(plannerIds);
+
+        if (userId == null) {
+            // Anonymous user - no vote/bookmark context needed
+            return planners.map(planner -> {
+                PublicPlannerResponse response = PublicPlannerResponse.fromEntity(planner);
+                response.setCommentCount(commentCountMap.getOrDefault(planner.getId(), 0L));
+                return response;
+            });
+        }
 
         // Batch query: 1 query for all votes (immutable - no deleted_at check needed)
         Set<UUID> upvotedIds = plannerVoteRepository
@@ -897,8 +902,27 @@ public class PlannerService {
         return planners.map(planner -> {
             Boolean hasUpvoted = upvotedIds.contains(planner.getId());
             Boolean isBookmarked = bookmarkedIds.contains(planner.getId());
-            return PublicPlannerResponse.fromEntity(planner, hasUpvoted, isBookmarked);
+            PublicPlannerResponse response = PublicPlannerResponse.fromEntity(planner, hasUpvoted, isBookmarked);
+            response.setCommentCount(commentCountMap.getOrDefault(planner.getId(), 0L));
+            return response;
         });
+    }
+
+    /**
+     * Batch fetch comment counts for a list of planner IDs.
+     *
+     * @param plannerIds list of planner IDs
+     * @return map of planner ID to non-deleted comment count
+     */
+    private Map<UUID, Long> batchFetchCommentCounts(List<UUID> plannerIds) {
+        if (plannerIds.isEmpty()) {
+            return Map.of();
+        }
+        return commentRepository.countByPlannerIdsGrouped(plannerIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> (Long) row[1]
+                ));
     }
 
     /**

--- a/backend/src/test/java/org/danteplanner/backend/dto/planner/PublicPlannerResponseTest.java
+++ b/backend/src/test/java/org/danteplanner/backend/dto/planner/PublicPlannerResponseTest.java
@@ -51,6 +51,40 @@ class PublicPlannerResponseTest {
     }
 
     @Nested
+    @DisplayName("commentCount Tests")
+    class CommentCountTests {
+
+        @Test
+        @DisplayName("commentCount is null when fromEntity called without setter")
+        void fromEntity_CommentCountIsNullByDefault() {
+            User user = createTestUser("test@example.com");
+            Planner planner = createTestPlanner(user);
+            PublicPlannerResponse response = PublicPlannerResponse.fromEntity(planner);
+            assertNull(response.getCommentCount());
+        }
+
+        @Test
+        @DisplayName("setCommentCount stores the value correctly")
+        void setCommentCount_StoresValue() {
+            User user = createTestUser("test@example.com");
+            Planner planner = createTestPlanner(user);
+            PublicPlannerResponse response = PublicPlannerResponse.fromEntity(planner);
+            response.setCommentCount(7L);
+            assertEquals(7L, response.getCommentCount());
+        }
+
+        @Test
+        @DisplayName("setCommentCount with zero is valid")
+        void setCommentCount_Zero_IsValid() {
+            User user = createTestUser("test@example.com");
+            Planner planner = createTestPlanner(user);
+            PublicPlannerResponse response = PublicPlannerResponse.fromEntity(planner);
+            response.setCommentCount(0L);
+            assertEquals(0L, response.getCommentCount());
+        }
+    }
+
+    @Nested
     @DisplayName("fromEntity Field Mapping Tests")
     class FieldMappingTests {
 

--- a/backend/src/test/java/org/danteplanner/backend/repository/PlannerCommentRepositoryTest.java
+++ b/backend/src/test/java/org/danteplanner/backend/repository/PlannerCommentRepositoryTest.java
@@ -1,0 +1,162 @@
+package org.danteplanner.backend.repository;
+
+import jakarta.persistence.EntityManager;
+
+import org.danteplanner.backend.config.TestConfig;
+import org.danteplanner.backend.entity.Planner;
+import org.danteplanner.backend.entity.PlannerComment;
+import org.danteplanner.backend.entity.User;
+import org.danteplanner.backend.support.TestDataFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Repository tests for PlannerCommentRepository batch count query.
+ *
+ * <p>Tests countByPlannerIdsGrouped which is used by PlannerService
+ * to batch-fetch comment counts for list views without N+1 queries.</p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestConfig.class)
+@Transactional
+class PlannerCommentRepositoryTest {
+
+    @Autowired
+    private PlannerCommentRepository commentRepository;
+
+    @Autowired
+    private PlannerRepository plannerRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private User testUser;
+    private Planner plannerA;
+    private Planner plannerB;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        plannerRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = TestDataFactory.createTestUser(userRepository, "test@example.com");
+        plannerA = TestDataFactory.createTestPlanner(plannerRepository, testUser, true);
+        plannerB = TestDataFactory.createTestPlanner(plannerRepository, testUser, true);
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private PlannerComment saveComment(UUID plannerId) {
+        PlannerComment comment = new PlannerComment(plannerId, testUser.getId(), "content", null, 0);
+        PlannerComment saved = commentRepository.save(comment);
+        entityManager.flush();
+        return saved;
+    }
+
+    private Map<UUID, Long> toMap(List<Object[]> rows) {
+        return rows.stream().collect(Collectors.toMap(
+                row -> (UUID) row[0],
+                row -> (Long) row[1]
+        ));
+    }
+
+    @Nested
+    @DisplayName("countByPlannerIdsGrouped Tests")
+    class CountByPlannerIdsGroupedTests {
+
+        @Test
+        @DisplayName("Returns empty list when plannerIds is empty")
+        void emptyInput_ReturnsEmptyList() {
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(List.of());
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Returns zero rows for planners with no comments")
+        void noComments_ReturnsNoRows() {
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(
+                    List.of(plannerA.getId(), plannerB.getId()));
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Returns correct count for a single planner with comments")
+        void singlePlannerWithComments_ReturnsCorrectCount() {
+            saveComment(plannerA.getId());
+            saveComment(plannerA.getId());
+            saveComment(plannerA.getId());
+
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(List.of(plannerA.getId()));
+            Map<UUID, Long> counts = toMap(result);
+
+            assertEquals(1, counts.size());
+            assertEquals(3L, counts.get(plannerA.getId()));
+        }
+
+        @Test
+        @DisplayName("Returns counts grouped per planner when multiple planners have comments")
+        void multiplePlanners_ReturnsCountsPerPlanner() {
+            saveComment(plannerA.getId());
+            saveComment(plannerA.getId());
+            saveComment(plannerB.getId());
+
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(
+                    List.of(plannerA.getId(), plannerB.getId()));
+            Map<UUID, Long> counts = toMap(result);
+
+            assertEquals(2L, counts.get(plannerA.getId()));
+            assertEquals(1L, counts.get(plannerB.getId()));
+        }
+
+        @Test
+        @DisplayName("Excludes soft-deleted comments from count")
+        void softDeletedComments_ExcludedFromCount() {
+            PlannerComment live = saveComment(plannerA.getId());
+            PlannerComment deleted = saveComment(plannerA.getId());
+
+            deleted.softDelete();
+            commentRepository.save(deleted);
+            entityManager.flush();
+            entityManager.clear();
+
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(List.of(plannerA.getId()));
+            Map<UUID, Long> counts = toMap(result);
+
+            assertEquals(1L, counts.get(plannerA.getId()));
+        }
+
+        @Test
+        @DisplayName("Only returns rows for planners in the input list")
+        void queryScoped_ToInputPlannerIds() {
+            saveComment(plannerA.getId());
+            saveComment(plannerB.getId());
+
+            // Query only plannerA
+            List<Object[]> result = commentRepository.countByPlannerIdsGrouped(List.of(plannerA.getId()));
+            Map<UUID, Long> counts = toMap(result);
+
+            assertEquals(1, counts.size());
+            assertNotNull(counts.get(plannerA.getId()));
+            assertNull(counts.get(plannerB.getId()));
+        }
+    }
+}

--- a/frontend/src/components/plannerList/PublishedPlannerCard.test.tsx
+++ b/frontend/src/components/plannerList/PublishedPlannerCard.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * PublishedPlannerCard.test.tsx
+ *
+ * Tests for PublishedPlannerCard stats row display.
+ * Verifies that upvotes, view count, and comment count are all rendered.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { PublicPlanner } from '@/types/PlannerListTypes'
+
+// Mock dependencies BEFORE importing component
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+vi.mock('@/lib/assetPaths', () => ({
+  getKeywordIconPath: (keyword: string) => `/icons/${keyword}.webp`,
+}))
+
+vi.mock('@/lib/formatDate', () => ({
+  formatPlannerDate: (date: string) => date,
+}))
+
+vi.mock('@/lib/formatUsername', () => ({
+  formatUsername: () => 'W_CORP#test1',
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(' '),
+}))
+
+// Import AFTER mocking
+import { PublishedPlannerCard } from './PublishedPlannerCard'
+
+function createMockPlanner(overrides: Partial<PublicPlanner> = {}): PublicPlanner {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    title: 'Test Planner',
+    plannerType: 'MIRROR_DUNGEON',
+    category: '5F',
+    selectedKeywords: [],
+    upvotes: 10,
+    viewCount: 200,
+    commentCount: 5,
+    authorUsernameEpithet: 'W_CORP',
+    authorUsernameSuffix: 'test1',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    lastModifiedAt: null,
+    hasUpvoted: null,
+    isBookmarked: null,
+    ...overrides,
+  }
+}
+
+describe('PublishedPlannerCard', () => {
+  describe('Stats Row', () => {
+    it('renders upvote count', () => {
+      render(<PublishedPlannerCard planner={createMockPlanner({ upvotes: 42 })} />)
+      expect(screen.getByText('42')).toBeInTheDocument()
+    })
+
+    it('renders view count', () => {
+      render(<PublishedPlannerCard planner={createMockPlanner({ viewCount: 999 })} />)
+      expect(screen.getByText('999')).toBeInTheDocument()
+    })
+
+    it('renders comment count', () => {
+      render(<PublishedPlannerCard planner={createMockPlanner({ commentCount: 7 })} />)
+      expect(screen.getByText('7')).toBeInTheDocument()
+    })
+
+    it('renders comment count of zero', () => {
+      render(<PublishedPlannerCard planner={createMockPlanner({ commentCount: 0 })} />)
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+
+    it('renders all three stats together', () => {
+      render(
+        <PublishedPlannerCard
+          planner={createMockPlanner({ upvotes: 10, viewCount: 200, commentCount: 5 })}
+        />,
+      )
+      expect(screen.getByText('10')).toBeInTheDocument()
+      expect(screen.getByText('200')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+  })
+
+  describe('Keywords Display', () => {
+    it('renders keyword icons', () => {
+      render(<PublishedPlannerCard planner={createMockPlanner({ selectedKeywords: ['Burn', 'Slash'] })} />)
+      expect(screen.getByAltText('Burn')).toBeInTheDocument()
+      expect(screen.getByAltText('Slash')).toBeInTheDocument()
+    })
+
+    it('shows +N overflow beyond 3 keywords', () => {
+      render(
+        <PublishedPlannerCard
+          planner={createMockPlanner({ selectedKeywords: ['Burn', 'Slash', 'Pierce', 'Blunt', 'Rupture'] })}
+        />,
+      )
+      expect(screen.getByText('+2')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/plannerList/PublishedPlannerCard.tsx
+++ b/frontend/src/components/plannerList/PublishedPlannerCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { ThumbsUp, Eye, Bookmark, Star, Clock } from 'lucide-react'
+import { ThumbsUp, Eye, Bookmark, Star, Clock, MessageSquare } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { formatPlannerDate } from '@/lib/formatDate'
@@ -60,6 +60,7 @@ export function PublishedPlannerCard({
     upvotes,
     // downvotes,  // TODO: Add when backend supports it
     viewCount,
+    commentCount,
     authorUsernameEpithet,
     authorUsernameSuffix,
     createdAt,
@@ -164,6 +165,12 @@ export function PublishedPlannerCard({
         <span className="flex items-center gap-1">
           <Eye className="size-3" />
           {viewCount}
+        </span>
+
+        {/* Comments */}
+        <span className="flex items-center gap-1">
+          <MessageSquare className="size-3" />
+          {commentCount}
         </span>
       </div>
 

--- a/frontend/src/schemas/PlannerListSchemas.ts
+++ b/frontend/src/schemas/PlannerListSchemas.ts
@@ -60,6 +60,8 @@ export const PublicPlannerSchema = z.object({
   hasUpvoted: z.boolean().nullable(),
   /** Whether current user has bookmarked (null if not authenticated) */
   isBookmarked: z.boolean().nullable(),
+  /** Total non-deleted comment count */
+  commentCount: z.number().int().min(0),
 })
 
 /**

--- a/frontend/src/types/PlannerListTypes.ts
+++ b/frontend/src/types/PlannerListTypes.ts
@@ -99,6 +99,8 @@ export interface PublicPlanner {
   hasUpvoted: boolean | null
   /** Whether current user has bookmarked this planner (null if not authenticated) */
   isBookmarked: boolean | null
+  /** Total non-deleted comment count */
+  commentCount: number
 }
 
 /**


### PR DESCRIPTION
Add commentCount to PublicPlannerResponse via a batch GROUP BY query to avoid N+1 queries when rendering the plan list. Both guest and authenticated users receive the count. Display it alongside upvotes and views in PublishedPlannerCard using the MessageSquare icon.