### PR TITLE
fix: harden credential handling across backend

### DIFF
--- a/backend/src/main/java/org/danteplanner/backend/controller/InternalController.java
+++ b/backend/src/main/java/org/danteplanner/backend/controller/InternalController.java
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.annotation.PostConstruct;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Map;
 
 /**
@@ -29,6 +33,13 @@ public class InternalController {
     @Value("${internal.api-key:}")
     private String apiKey;
 
+    @PostConstruct
+    void validateApiKey() {
+        if (apiKey.isBlank()) {
+            log.warn("internal.api-key is not configured — /api/internal endpoints will reject all requests");
+        }
+    }
+
     /**
      * Reload game data from static JSON files.
      *
@@ -39,7 +50,9 @@ public class InternalController {
     public ResponseEntity<Map<String, String>> refreshGameData(
             @RequestHeader("X-Internal-Api-Key") String providedKey) {
 
-        if (apiKey.isEmpty() || !apiKey.equals(providedKey)) {
+        if (apiKey.isBlank() || !MessageDigest.isEqual(
+                apiKey.getBytes(StandardCharsets.UTF_8),
+                providedKey.getBytes(StandardCharsets.UTF_8))) {
             log.warn("Unauthorized refresh-game-data attempt");
             return ResponseEntity.status(403)
                     .body(Map.of("error", "Invalid API key"));

--- a/backend/src/main/java/org/danteplanner/backend/facade/AuthenticationFacade.java
+++ b/backend/src/main/java/org/danteplanner/backend/facade/AuthenticationFacade.java
@@ -95,7 +95,7 @@ public class AuthenticationFacade {
                 user = deletedUser.get();
                 lifecycleService.reactivateAccount(user.getId());
                 reactivated = true;
-                log.info("Reactivated soft-deleted account for user: {}", user.getEmail());
+                log.info("Reactivated soft-deleted account for user: {}", user.getId());
             } else if (deletedUser.isPresent()) {
                 // User exists but not deleted - use as-is
                 user = deletedUser.get();
@@ -117,8 +117,8 @@ public class AuthenticationFacade {
         String accessToken = tokenGenerator.generateAccessToken(user.getId(), user.getEmail(), user.getRole());
         String refreshToken = tokenGenerator.generateRefreshToken(user.getId(), user.getEmail());
 
-        log.info("User authenticated successfully via {}: {} (reactivated: {})",
-                providerName, user.getEmail(), reactivated);
+        log.info("User authenticated successfully via {}: userId={} (reactivated: {})",
+                providerName, user.getId(), reactivated);
         return new AuthResult(user, accessToken, refreshToken, reactivated);
     }
 
@@ -164,7 +164,7 @@ public class AuthenticationFacade {
         String newAccessToken = tokenGenerator.generateAccessToken(user.getId(), user.getEmail(), user.getRole());
         String newRefreshToken = tokenGenerator.generateRefreshToken(user.getId(), user.getEmail());
 
-        log.info("Token refreshed successfully for user: {}", user.getEmail());
+        log.info("Token refreshed successfully for user: {}", user.getId());
         return new AuthResult(user, newAccessToken, newRefreshToken, false);
     }
 

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -3,6 +3,7 @@
 
 # Database Configuration (Docker hostnames)
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST:mysql}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.flyway.url=jdbc:mysql://${MYSQL_HOST:mysql}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 
 # CORS Configuration (Docker nginx + frontend dev server)
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -2,8 +2,8 @@
 # Activate with: SPRING_PROFILES_ACTIVE=prod
 
 # Database Configuration
-# Override with production database URL
-# spring.datasource.url=jdbc:mysql://production-db-host:3306/danteplanner?useSSL=true&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?useSSL=true&serverTimezone=UTC
+spring.flyway.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT:3306}/${MYSQL_DATABASE}?useSSL=true&serverTimezone=UTC
 
 # CORS Configuration
 cors.allowed-origins=https://dante-planner.com

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.open-in-view=false
 # Flyway Configuration
 spring.flyway.enabled=true
 spring.flyway.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.flyway.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:danteplanner}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.flyway.url=jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:danteplanner}?serverTimezone=UTC
 spring.flyway.user=${MYSQL_USER:danteplanner}
 spring.flyway.password=${MYSQL_PASSWORD:}
 spring.flyway.baseline-on-migrate=false

--- a/backend/src/test/resources/test-keys/aes_key.txt
+++ b/backend/src/test/resources/test-keys/aes_key.txt
@@ -1,1 +1,0 @@
-E9dzesGJ+MrmIaVssATsvvP9EOc1M/Cj/u+9Bh1WTBg=


### PR DESCRIPTION
The backend handles API key comparison, database connections, and authentication logging across multiple configuration profiles.

Prior to this commit, the internal API key was compared with a timing-vulnerable method, the base Flyway URL exposed insecure connection flags to all profiles including production, and user email addresses were logged at INFO level in production.

This commit uses constant-time comparison for API key validation, isolates insecure database flags to the dev profile only, enforces SSL in the prod profile, removes a redundant plaintext key file, and replaces email with user ID in production log messages.