### PR TITLE
fix(ops): restore backup pipeline and alarm on silence

### DIFF
--- a/scripts/ops/aws-backup.sh
+++ b/scripts/ops/aws-backup.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-west-2}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+PROJECT_DIR="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+SCRIPT_DIR="$PROJECT_DIR/scripts/ops"
 BACKUP_DIR="/tmp/danteplanner-backups"
 S3_BUCKET="${S3_BACKUP_BUCKET:-danteplanner-backups}"
 RETENTION_DAYS=7
@@ -66,6 +66,13 @@ else
     echo "[$(date)] ERROR: S3 upload failed"
     exit 1
 fi
+
+aws cloudwatch put-metric-data \
+    --namespace "DantePlanner" \
+    --metric-name "BackupSuccess" \
+    --dimensions "Job=MysqlDump" \
+    --value 1 \
+    --region "$AWS_DEFAULT_REGION"
 
 # Clean up local backup
 rm -f "$BACKUP_FILE"

--- a/scripts/ops/export-cloudwatch-logs.sh
+++ b/scripts/ops/export-cloudwatch-logs.sh
@@ -84,4 +84,11 @@ for LOG_GROUP in "${LOG_GROUPS[@]}"; do
     wait_for_export "$TASK_ID" "$LOG_GROUP"
 done
 
+aws cloudwatch put-metric-data \
+    --namespace "DantePlanner" \
+    --metric-name "BackupSuccess" \
+    --dimensions "Job=CwLogExport" \
+    --value 1 \
+    --region "$AWS_DEFAULT_REGION"
+
 echo "[$(date -u)] CloudWatch log export complete"

--- a/scripts/ops/setup-cloudwatch-alarms.sh
+++ b/scripts/ops/setup-cloudwatch-alarms.sh
@@ -439,6 +439,43 @@ create_alarms() {
         --treat-missing-data breaching \
         --region "$AWS_REGION"
 
+    # Alarm 11: MySQL Backup Silence — daily S3 dump must emit BackupSuccess once per 24h.
+    # breaching = missing datapoint treated as alarm, so a failed/absent cron fires immediately.
+    log_info "Creating MySQL backup silence alarm..."
+    aws cloudwatch put-metric-alarm \
+        --alarm-name "DantePlanner-MysqlBackupSilence" \
+        --alarm-description "No successful MySQL backup in the last 24 hours" \
+        --namespace "$NAMESPACE" \
+        --metric-name "BackupSuccess" \
+        --dimensions Name=Job,Value=MysqlDump \
+        --statistic Sum \
+        --period 86400 \
+        --threshold 1 \
+        --comparison-operator LessThanThreshold \
+        --evaluation-periods 1 \
+        --alarm-actions "$TOPIC_ARN" \
+        --ok-actions "$TOPIC_ARN" \
+        --treat-missing-data breaching \
+        --region "$AWS_REGION"
+
+    # Alarm 12: CloudWatch Log Export Silence — daily CW→S3 export heartbeat.
+    log_info "Creating CloudWatch export silence alarm..."
+    aws cloudwatch put-metric-alarm \
+        --alarm-name "DantePlanner-CwExportSilence" \
+        --alarm-description "No successful CloudWatch log export in the last 24 hours" \
+        --namespace "$NAMESPACE" \
+        --metric-name "BackupSuccess" \
+        --dimensions Name=Job,Value=CwLogExport \
+        --statistic Sum \
+        --period 86400 \
+        --threshold 1 \
+        --comparison-operator LessThanThreshold \
+        --evaluation-periods 1 \
+        --alarm-actions "$TOPIC_ARN" \
+        --ok-actions "$TOPIC_ARN" \
+        --treat-missing-data breaching \
+        --region "$AWS_REGION"
+
     log_info "All alarms created successfully"
 }
 
@@ -732,7 +769,7 @@ print_summary() {
     echo ""
     echo "Created Resources:"
     echo "  - SNS Topic: $SNS_TOPIC_NAME"
-    echo "  - Alarms: HighCPU, LowMemory, HighDisk, HighNetworkIn, HighNetworkOut, HighDiskIOWrite, HTTP5xx, BackendErrors, BackendWarnings, BackendSilence"
+    echo "  - Alarms: HighCPU, LowMemory, HighDisk, HighNetworkIn, HighNetworkOut, HighDiskIOWrite, HTTP5xx, BackendErrors, BackendWarnings, BackendSilence, MysqlBackupSilence, CwExportSilence"
     echo "  - Metric Filters: HTTP5xxErrors (nginx), BackendErrors, BackendWarnings, BackendHeartbeat (backend)"
     echo "  - Dashboard: DantePlanner (System Resources widget + 10 alarms + log insights from /ecs/danteplanner/backend)"
     echo "  - Insights Queries (15): 9 backend, 4 nginx, 2 mysql"


### PR DESCRIPTION
aws-backup.sh PROJECT_DIR used a single dirname after the scripts/ops reorg, so .env resolved to /opt/danteplanner/scripts and MYSQL_* env vars went unset, aborting every cron run since March 1. Use two dirname calls to land at the project root.

Both aws-backup.sh and export-cloudwatch-logs.sh now emit a DantePlanner/BackupSuccess datapoint with a Job dimension after completing successfully. MysqlBackupSilence and CwExportSilence alarms watch these with a 24h period, LessThanThreshold=1, and treat-missing-data=breaching, so a single missed day pages immediately.