### PR TITLE
refactor(ci): split cron and shell setup into dedicated workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,23 +184,12 @@ jobs:
           GITHUB_REPOSITORY=__GITHUB_REPO__
           CONFIG
 
-          DEPLOY_ERRORS=""
-
           # Critical steps - fail fast
           sudo bash scripts/deploy/install-prerequisites.sh || { echo "[FATAL] Prerequisites failed at exit $?"; exit 1; }
           sudo -u ec2-user bash scripts/deploy/setup-env.sh || { echo "[FATAL] Environment setup failed at exit $?"; exit 1; }
           sudo -u ec2-user bash scripts/deploy/deploy-containers.sh "__CHANGED_SERVICES__" || { echo "[FATAL] Container deploy failed at exit $?"; exit 1; }
 
-          # Non-critical steps - collect errors, continue
-          sudo -u ec2-user bash scripts/deploy/setup-cron.sh || DEPLOY_ERRORS="${DEPLOY_ERRORS}cron: exit $?\n"
-          sudo -u ec2-user bash scripts/deploy/setup-shell.sh || DEPLOY_ERRORS="${DEPLOY_ERRORS}shell: exit $?\n"
-
           rm -f /tmp/deploy-config.env
-
-          if [ -n "$DEPLOY_ERRORS" ]; then
-            echo "[WARN] Non-critical failures:"
-            echo -e "$DEPLOY_ERRORS"
-          fi
           EOF
 
           # Replace placeholders with actual values from env vars

--- a/.github/workflows/setup-cron.yml
+++ b/.github/workflows/setup-cron.yml
@@ -1,0 +1,76 @@
+name: Setup Cron
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/deploy/setup-cron.sh'
+      - 'scripts/ops/**'
+      - '.github/workflows/setup-cron.yml'
+
+jobs:
+  setup-cron:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Register crontab via SSM
+        env:
+          INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          cat <<'EOF' > cron_script.sh
+          cd /opt/danteplanner
+
+          command -v git &> /dev/null || yum install -y git
+          if [ ! -d "/opt/danteplanner/.git" ]; then
+            sudo -u ec2-user git clone https://github.com/__GITHUB_REPO__ /opt/danteplanner
+          else
+            sudo -u ec2-user git -C /opt/danteplanner fetch origin main
+            sudo -u ec2-user git -C /opt/danteplanner reset --hard origin/main
+          fi
+
+          sudo -u ec2-user bash -e <<'INNER_BATCH'
+          cd /opt/danteplanner
+          bash scripts/deploy/setup-cron.sh
+          INNER_BATCH
+          EOF
+
+          sed -i "s|__GITHUB_REPO__|$GITHUB_REPO|g" cron_script.sh
+
+          jq -n --rawfile cmd cron_script.sh '{"commands": [$cmd]}' > cron_params.json
+
+          RAW_COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file://cron_params.json \
+            --query "Command.CommandId" --output text)
+
+          COMMAND_ID=$(echo $RAW_COMMAND_ID | tr -d '"' | tr -d ' ')
+          CLEAN_INSTANCE_ID=$(echo "$INSTANCE_ID" | tr -d '"' | tr -d ' ')
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$CLEAN_INSTANCE_ID" || true
+
+          RESULT=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$CLEAN_INSTANCE_ID")
+
+          STATUS=$(echo "$RESULT" | jq -r '.Status')
+          echo "Status: $STATUS"
+          echo "--- STDOUT ---"
+          echo "$RESULT" | jq -r '.StandardOutputContent'
+
+          if [ "$STATUS" != "Success" ]; then
+            echo "--- STDERR ---"
+            echo "$RESULT" | jq -r '.StandardErrorContent'
+            exit 1
+          fi

--- a/.github/workflows/setup-cron.yml
+++ b/.github/workflows/setup-cron.yml
@@ -9,6 +9,9 @@ on:
       - 'scripts/ops/**'
       - '.github/workflows/setup-cron.yml'
 
+permissions:
+  contents: read
+
 jobs:
   setup-cron:
     runs-on: ubuntu-latest

--- a/.github/workflows/setup-shell.yml
+++ b/.github/workflows/setup-shell.yml
@@ -8,6 +8,9 @@ on:
       - 'scripts/deploy/setup-shell.sh'
       - '.github/workflows/setup-shell.yml'
 
+permissions:
+  contents: read
+
 jobs:
   setup-shell:
     runs-on: ubuntu-latest

--- a/.github/workflows/setup-shell.yml
+++ b/.github/workflows/setup-shell.yml
@@ -1,0 +1,75 @@
+name: Setup Shell
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/deploy/setup-shell.sh'
+      - '.github/workflows/setup-shell.yml'
+
+jobs:
+  setup-shell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install shell aliases via SSM
+        env:
+          INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          cat <<'EOF' > shell_script.sh
+          cd /opt/danteplanner
+
+          command -v git &> /dev/null || yum install -y git
+          if [ ! -d "/opt/danteplanner/.git" ]; then
+            sudo -u ec2-user git clone https://github.com/__GITHUB_REPO__ /opt/danteplanner
+          else
+            sudo -u ec2-user git -C /opt/danteplanner fetch origin main
+            sudo -u ec2-user git -C /opt/danteplanner reset --hard origin/main
+          fi
+
+          sudo -u ec2-user bash -e <<'INNER_BATCH'
+          cd /opt/danteplanner
+          bash scripts/deploy/setup-shell.sh
+          INNER_BATCH
+          EOF
+
+          sed -i "s|__GITHUB_REPO__|$GITHUB_REPO|g" shell_script.sh
+
+          jq -n --rawfile cmd shell_script.sh '{"commands": [$cmd]}' > shell_params.json
+
+          RAW_COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file://shell_params.json \
+            --query "Command.CommandId" --output text)
+
+          COMMAND_ID=$(echo $RAW_COMMAND_ID | tr -d '"' | tr -d ' ')
+          CLEAN_INSTANCE_ID=$(echo "$INSTANCE_ID" | tr -d '"' | tr -d ' ')
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$CLEAN_INSTANCE_ID" || true
+
+          RESULT=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$CLEAN_INSTANCE_ID")
+
+          STATUS=$(echo "$RESULT" | jq -r '.Status')
+          echo "Status: $STATUS"
+          echo "--- STDOUT ---"
+          echo "$RESULT" | jq -r '.StandardOutputContent'
+
+          if [ "$STATUS" != "Success" ]; then
+            echo "--- STDERR ---"
+            echo "$RESULT" | jq -r '.StandardErrorContent'
+            exit 1
+          fi


### PR DESCRIPTION
setup-cron.sh and setup-shell.sh ran on every container deploy as "non-critical" steps guarded by a DEPLOY_ERRORS accumulator. That coupled host-configuration concerns to container rollouts and normalized silent failures: a broken cron setup would log a warning and be forgotten.

Move each into its own path-filtered workflow mirroring setup-cloudwatch.yml: setup-cron.yml triggers on changes to scripts/deploy/setup-cron.sh or scripts/ops/**, setup-shell.yml on scripts/deploy/setup-shell.sh. Both also support workflow_dispatch. deploy.yml now runs only critical steps, so any deploy failure is a real failure rather than a swallowed warning.