### PR TITLE
v260416

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,4 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "dev"


### PR DESCRIPTION
- Reflect Limbus Company's 260416 update
- Fix some E.G.O gifts' missing images
- Known issue: abEvent 971107 misses its image
- Redirect dependabot's Github Action update to dev branch