### PR TITLE
v260430-2

### DIFF
--- a/frontend/src/components/identity/SkillCard.tsx
+++ b/frontend/src/components/identity/SkillCard.tsx
@@ -30,6 +30,21 @@ function getMergedSkillData(
 }
 
 /**
+ * Smallest 1-based uptie at which the skill is first defined.
+ * Empty `{}` slots before that level mean "not yet introduced" (not "inherit"),
+ * so the renderer should lock and display this skill at its first defined level.
+ * Falls back to 1 when no slot has data — keeps the card visible rather than blank.
+ */
+export function getFirstDefinedUptie(skillData: IdentitySkillEntry['skillData']): Uptie {
+  for (let i = 0; i < skillData.length; i++) {
+    if (Object.keys(skillData[i]).length > 0) {
+      return (i + 1) as Uptie
+    }
+  }
+  return 1
+}
+
+/**
  * SkillCard with granular i18n Suspense.
  * Structure (image, stats) stays visible, only name/description suspends.
  */

--- a/frontend/src/components/identity/SkillI18n.tsx
+++ b/frontend/src/components/identity/SkillI18n.tsx
@@ -1,4 +1,4 @@
-import { SkillCardWithGranularI18n } from './SkillCard'
+import { SkillCardWithGranularI18n, getFirstDefinedUptie } from './SkillCard'
 import type { IdentitySkillEntry, Uptie } from '@/types/IdentityTypes'
 
 type SkillSlot = 'skill1' | 'skill2' | 'skill3' | 'skillDef'
@@ -12,8 +12,6 @@ interface SkillsSectionI18nProps {
   activeSkillSlot: SkillSlot
   /** Current uptie level (1-4) */
   uptieLevel: Uptie
-  /** Whether skill 3 is locked (uptie < 3) */
-  isSkill3Locked: boolean
   /** Function to convert slot to numeric slot number */
   getSkillSlotNumber: (slot: SkillSlot) => number
 }
@@ -21,21 +19,25 @@ interface SkillsSectionI18nProps {
 /**
  * Skill section with granular i18n Suspense.
  * Structure stays visible, only name/description suspends.
+ *
+ * Locking is per-skill: a card whose first defined uptie is above the
+ * currently selected uptie renders at its first defined level with a
+ * lock overlay. This generalizes the old "skill3 unlocks at uptie 3"
+ * rule to skills like 1061405 (uptie 2) and 1071505 (uptie 4).
  */
 export function SkillsSectionI18n({
   id,
   skills,
   activeSkillSlot,
   uptieLevel,
-  isSkill3Locked,
   getSkillSlotNumber,
 }: SkillsSectionI18nProps) {
-  const isCurrentSkillLocked = activeSkillSlot === 'skill3' && isSkill3Locked
-
   return (
     <div className="border rounded divide-y">
       {skills[activeSkillSlot].map((skill) => {
-        const displayUptie = isCurrentSkillLocked ? 3 as Uptie : uptieLevel
+        const firstDefinedUptie = getFirstDefinedUptie(skill.skillData)
+        const isLocked = uptieLevel < firstDefinedUptie
+        const displayUptie = isLocked ? firstDefinedUptie : uptieLevel
 
         return (
           <SkillCardWithGranularI18n
@@ -44,7 +46,7 @@ export function SkillsSectionI18n({
             skillSlot={getSkillSlotNumber(activeSkillSlot)}
             skillEntry={skill}
             uptie={displayUptie}
-            isLocked={isCurrentSkillLocked}
+            isLocked={isLocked}
           />
         )
       })}

--- a/frontend/src/routes/IdentityDetailPage.tsx
+++ b/frontend/src/routes/IdentityDetailPage.tsx
@@ -307,7 +307,6 @@ function IdentityDetailContent() {
         skills={identityData.skills}
         activeSkillSlot={activeSkillSlot}
         uptieLevel={uptieLevel}
-        isSkill3Locked={isSkill3Locked}
         getSkillSlotNumber={getSkillSlotNumber}
       />
     </div>


### PR DESCRIPTION
- Fix skill representation of Uptie 4 only skills
- Remove defense-derived internal skills
- Korean - prevent 버림 in 소숫점 버림 from being keywordlized