### PR TITLE
ci: skip announcement tags in detect-changes diff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,16 +49,16 @@ jobs:
             NGINX_CHANGED=true
             MYSQL_CHANGED=true
           else
-            LAST_TAG=$(git describe --tags --match 'v*' --abbrev=0 HEAD^ 2>/dev/null || true)
+            PREV_TAG=$(git tag --sort=-creatordate --list 'v*' --merged HEAD^ | sed -n '2p')
 
-            if [ -z "$LAST_TAG" ]; then
-              echo "No prior release tag found - deploying all services"
+            if [ -z "$PREV_TAG" ]; then
+              echo "Fewer than two prior release tags - deploying all services"
               BACKEND_CHANGED=true
               NGINX_CHANGED=true
               MYSQL_CHANGED=true
             else
-              echo "Diffing $LAST_TAG..HEAD"
-              CHANGED=$(git diff --name-only "$LAST_TAG" HEAD)
+              echo "Diffing $PREV_TAG..HEAD"
+              CHANGED=$(git diff --name-only "$PREV_TAG" HEAD)
               echo "Changed files:"
               echo "$CHANGED"
 


### PR DESCRIPTION
The announcement skill writes v{YYMMDD} tags into the same namespace deploy uses. When an announcement push lands at HEAD^, git describe sees that tag and collapses LAST_TAG..HEAD to the tip commit, hiding any backend changes pushed just before — which is why the lineage refresh-token rotation never deployed.

Switch the diff base to the second-most-recent v* tag reachable from HEAD^. The announcement commit becomes part of the window instead of bounding it, so buried backend changes are surfaced.