### PR TITLE
fix: converge sync versions across mounted planner surfaces

### DIFF
--- a/frontend/src/pages/planner/hooks/__tests__/usePlannerSave.test.ts
+++ b/frontend/src/pages/planner/hooks/__tests__/usePlannerSave.test.ts
@@ -14,6 +14,7 @@
 
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { queryClient } from '@/lib/queryClient'
 import { createPlannerEditorStore } from '../../stores/usePlannerEditorStore'
 import type { PlannerState, UsePlannerSaveOptions } from '../usePlannerSave'
 import type { SaveResult } from '../usePlannerStorage'
@@ -71,7 +72,9 @@ vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>()
   return {
     ...actual,
-    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+    useTranslation: () => ({
+      t: (_key: string, fallback?: string) => fallback ?? _key,
+    }),
   }
 })
 
@@ -100,7 +103,9 @@ function baseOptions(overrides: Partial<UsePlannerSaveOptions> = {}): UsePlanner
 }
 
 function authenticated() {
-  mockUseAuthQuery.mockReturnValue({ data: { id: 'u1', isBanned: false, isTimedOut: false } })
+  mockUseAuthQuery.mockReturnValue({
+    data: { id: 'u1', isBanned: false, isTimedOut: false },
+  })
 }
 
 beforeEach(() => {
@@ -108,7 +113,9 @@ beforeEach(() => {
   callOrder.length = 0
   mockGetOrCreateDeviceId.mockResolvedValue('device-123')
   mockSaveToLocal.mockResolvedValue({ success: true })
-  mockSyncToServer.mockResolvedValue({ metadata: { syncVersion: 5 } } as SaveablePlanner)
+  mockSyncToServer.mockResolvedValue({
+    metadata: { syncVersion: 5 },
+  } as SaveablePlanner)
 })
 
 describe('usePlannerSave - save() golden master', () => {
@@ -167,7 +174,9 @@ describe('usePlannerSave - save() golden master', () => {
 
   it('adopts the syncVersion returned by the server', async () => {
     authenticated()
-    mockSyncToServer.mockResolvedValue({ metadata: { syncVersion: 42 } } as SaveablePlanner)
+    mockSyncToServer.mockResolvedValue({
+      metadata: { syncVersion: 42 },
+    } as SaveablePlanner)
     const { result } = renderHook(() => usePlannerSave(baseOptions()))
 
     await act(async () => {
@@ -243,7 +252,10 @@ describe('usePlannerSave - draft vs published path selection', () => {
 describe('usePlannerSave - error surface', () => {
   it('maps a quotaExceeded local-save failure to the quotaExceeded error code', async () => {
     authenticated()
-    mockSaveToLocal.mockResolvedValue({ success: false, errorCode: 'quotaExceeded' })
+    mockSaveToLocal.mockResolvedValue({
+      success: false,
+      errorCode: 'quotaExceeded',
+    })
     const { result } = renderHook(() => usePlannerSave(baseOptions()))
 
     let outcome: boolean | undefined
@@ -287,7 +299,9 @@ describe('usePlannerSave - error surface', () => {
   })
 
   it('reports restriction state for a banned user', () => {
-    mockUseAuthQuery.mockReturnValue({ data: { id: 'u1', isBanned: true, banReason: 'spam' } })
+    mockUseAuthQuery.mockReturnValue({
+      data: { id: 'u1', isBanned: true, banReason: 'spam' },
+    })
     const { result } = renderHook(() => usePlannerSave(baseOptions()))
 
     expect(result.current.isRestricted).toBe(true)
@@ -343,7 +357,9 @@ describe('usePlannerSave - resolveConflict adapter ordering (golden master)', ()
   beforeEach(() => {
     // Resolution branches read a server planner; default it to a truthy value with a
     // syncVersion so the if (serverPlanner) blocks execute (fetch -> local -> callbacks).
-    mockFetchFromServer.mockResolvedValue({ metadata: { syncVersion: 9 } } as SaveablePlanner)
+    mockFetchFromServer.mockResolvedValue({
+      metadata: { syncVersion: 9 },
+    } as SaveablePlanner)
   })
 
   it('overwrite force-saves via performSave: sync THEN local, clears conflict', async () => {
@@ -385,7 +401,10 @@ describe('usePlannerSave - resolveConflict adapter ordering (golden master)', ()
     authenticated()
     const onServerReload = vi.fn()
     const onKeepBothCreated = vi.fn()
-    const { result } = await driveIntoConflict({ onServerReload, onKeepBothCreated })
+    const { result } = await driveIntoConflict({
+      onServerReload,
+      onKeepBothCreated,
+    })
 
     let outcome: boolean | undefined
     await act(async () => {
@@ -420,5 +439,92 @@ describe('usePlannerSave - resolveConflict adapter ordering (golden master)', ()
     expect(outcome).toBe(true)
     expect(callOrder).toEqual(['local', 'fetch', 'local'])
     expect(onKeepBothCreated).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('usePlannerSave - cross-surface version convergence', () => {
+  // performSave mutates the payload object after the server responds (it writes
+  // the returned syncVersion back into `saveable`), so mock.calls[i][0] reads the
+  // post-mutation value — the presented version must be captured at call time.
+  function captureSentVersions(): number[] {
+    const sentVersions: number[] = []
+    mockSyncToServer.mockImplementation((planner: SaveablePlanner) => {
+      sentVersions.push(planner.metadata.syncVersion)
+      return Promise.resolve({
+        metadata: { syncVersion: planner.metadata.syncVersion + 1 },
+      } as SaveablePlanner)
+    })
+    return sentVersions
+  }
+
+  it('presents the advanced initialSyncVersion on the next save after a rerender', async () => {
+    authenticated()
+    const plannerId = '11111111-1111-4111-8111-111111111111'
+    const sentVersions = captureSentVersions()
+    const { result, rerender } = renderHook(
+      (props: UsePlannerSaveOptions) => usePlannerSave(props),
+      {
+        initialProps: baseOptions({
+          initialPlannerId: plannerId,
+          initialSyncVersion: 1,
+        }),
+      },
+    )
+
+    // Another surface (publish header, conflict force) advanced the server
+    // version; its write-through re-renders this hook with the new version.
+    rerender(baseOptions({ initialPlannerId: plannerId, initialSyncVersion: 5 }))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(sentVersions).toEqual([5])
+  })
+
+  it('never rolls the version back when a lagging initialSyncVersion arrives', async () => {
+    authenticated()
+    const plannerId = '11111111-1111-4111-8111-111111111111'
+    const sentVersions = captureSentVersions()
+    const { result, rerender } = renderHook(
+      (props: UsePlannerSaveOptions) => usePlannerSave(props),
+      {
+        initialProps: baseOptions({
+          initialPlannerId: plannerId,
+          initialSyncVersion: 6,
+        }),
+      },
+    )
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    rerender(baseOptions({ initialPlannerId: plannerId, initialSyncVersion: 3 }))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(sentVersions).toEqual([6, 7])
+  })
+
+  it('refreshes the planner and userPlanners caches after a synced save', async () => {
+    authenticated()
+    const plannerId = '11111111-1111-4111-8111-111111111111'
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const { result } = renderHook(() =>
+      usePlannerSave(baseOptions({ initialPlannerId: plannerId, initialSyncVersion: 1 })),
+    )
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['planner', plannerId],
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['userPlanners'] })
+    invalidateSpy.mockRestore()
   })
 })

--- a/frontend/src/pages/planner/hooks/usePlannerSave.ts
+++ b/frontend/src/pages/planner/hooks/usePlannerSave.ts
@@ -4,6 +4,8 @@ import i18n from '@/lib/i18n'
 import { useAuthQuery } from '@/shared/auth'
 import { usePlannerSaveAdapter } from './usePlannerSaveAdapter'
 import { usePlannerSyncAdapter } from './usePlannerSyncAdapter'
+import { plannerQueryKeys } from './useSavedPlannerQuery'
+import { userPlannersQueryKeys } from './useMDUserPlannersData'
 import { useEGOGiftListData } from '@/pages/egoGift'
 import { serializeSets } from '../schemas/PlannerSchemas'
 import {
@@ -348,6 +350,17 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
   // Track sync version for optimistic locking
   const syncVersionRef = useRef<number>(initialSyncVersion ?? 1)
 
+  // Another surface (publish header, conflict resolution) may advance the server
+  // version while this instance stays mounted; its cache write-through re-renders
+  // this hook with a newer initialSyncVersion. Adopt forward-only — a lagging
+  // prop must never roll back a version this instance already holds, or the next
+  // save would present a stale version and conflict (409).
+  useEffect(() => {
+    if (initialSyncVersion !== undefined && initialSyncVersion > syncVersionRef.current) {
+      syncVersionRef.current = initialSyncVersion
+    }
+  }, [initialSyncVersion])
+
   // Error state
   const [errorCode, setErrorCode] = useState<SaveErrorCode>(null)
   const [errorI18nKey, setErrorI18nKey] = useState<string | null>(null)
@@ -366,16 +379,31 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
    * Used in both performSave and resolveConflict to surface validation failures.
    */
   const throwValidationError = (friendly: { key: string; params?: Record<string, string> }) => {
-    const errorMessage = JSON.stringify({ key: friendly.key, params: friendly.params })
+    const errorMessage = JSON.stringify({
+      key: friendly.key,
+      params: friendly.params,
+    })
     const error = new Error(errorMessage)
     ;(
-      error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }
+      error as Error & {
+        code: string
+        i18nKey: string
+        i18nParams?: Record<string, string>
+      }
     ).code = 'userFriendlyValidation'
     ;(
-      error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }
+      error as Error & {
+        code: string
+        i18nKey: string
+        i18nParams?: Record<string, string>
+      }
     ).i18nKey = friendly.key
     ;(
-      error as Error & { code: string; i18nKey: string; i18nParams?: Record<string, string> }
+      error as Error & {
+        code: string
+        i18nKey: string
+        i18nParams?: Record<string, string>
+      }
     ).i18nParams = friendly.params
     throw error
   }
@@ -449,8 +477,10 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
       }
 
       // If authenticated AND (syncEnabled OR forceSync), sync to server first to get new syncVersion
+      let didSync = false
       if (isAuthenticated && (syncEnabled || forceSync)) {
         const synced = await syncAdapter.syncToServer(saveable, force)
+        didSync = true
 
         // Update sync version from server response
         if (synced.metadata.syncVersion) {
@@ -465,6 +495,18 @@ export function usePlannerSave(options: UsePlannerSaveOptions): PlannerSaveResul
         const error = new Error(`Local save failed: ${localResult.errorCode}`)
         ;(error as Error & { code: string }).code = localResult.errorCode ?? 'saveFailed'
         throw error
+      }
+
+      // Write-through: every mounted consumer (publish header, list pages) must
+      // see the server-assigned version without relying on an SSE echo — the
+      // originating device is excluded from its own events by design.
+      if (didSync) {
+        void queryClient.invalidateQueries({
+          queryKey: plannerQueryKeys.detail(plannerId),
+        })
+        void queryClient.invalidateQueries({
+          queryKey: userPlannersQueryKeys.all,
+        })
       }
 
       return true


### PR DESCRIPTION
A mounted usePlannerSave instance froze its syncVersion at mount and updated it only from its own sync responses. When another surface (publish header, conflict force) advanced the server version, the mounted instance kept presenting the stale one and every subsequent save conflicted (409) — one step behind forever. The removed SSE self-echo had been masking this by accidentally refreshing caches after every save.

Adopt initialSyncVersion advances into the ref (forward-only, so a lagging prop can never roll it back), and invalidate the planner and userPlanners caches after every synced save so all mounted consumers converge by design rather than by echo.