### PR TITLE
fix: base64url-encode read-your-writes GTID cookie

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,27 @@ COPY backend/src ./src
 RUN --mount=type=cache,target=/root/.gradle \
     gradle bootJar --no-daemon
 
+# Bake the public Amazon RDS CA bundle into a PKCS12 truststore so the backend
+# can verify the RDS server certificate (sslMode=VERIFY_CA). The bundle is
+# public; the store password guards integrity only, not confidentiality.
+# Runs on $BUILDPLATFORM so keytool executes natively (not under QEMU on the
+# amd64 runner) and the layer caches independently of app code and game data;
+# the resulting .p12 is architecture-independent.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jre-alpine AS rds-certs
+
+RUN set -eux; \
+    apk add --no-cache curl; \
+    mkdir -p /app/certs; \
+    curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /tmp/rds-bundle.pem; \
+    awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/tmp/rds-cert-" c ".pem")}' /tmp/rds-bundle.pem; \
+    for cert in /tmp/rds-cert-*.pem; do \
+      grep -q 'BEGIN CERTIFICATE' "$cert" || continue; \
+      keytool -importcert -noprompt -alias "rds-$(basename "$cert" .pem)" \
+        -file "$cert" -keystore /app/certs/rds-truststore.p12 \
+        -storetype PKCS12 -storepass changeit; \
+    done; \
+    rm -f /tmp/rds-bundle.pem /tmp/rds-cert-*.pem
+
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
@@ -27,20 +48,7 @@ COPY --from=builder /app/build/libs/*.jar app.jar
 COPY static/data /app/data
 ENV GAME_DATA_PATH=/app/data
 
-# Bake the public Amazon RDS CA bundle into a PKCS12 truststore so the backend
-# can verify the RDS server certificate (sslMode=VERIFY_CA). The bundle is
-# public; the store password guards integrity only, not confidentiality.
-RUN set -eux; \
-    mkdir -p /app/certs; \
-    curl -fsSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /tmp/rds-bundle.pem; \
-    awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/tmp/rds-cert-" c ".pem")}' /tmp/rds-bundle.pem; \
-    for cert in /tmp/rds-cert-*.pem; do \
-      grep -q 'BEGIN CERTIFICATE' "$cert" || continue; \
-      keytool -importcert -noprompt -alias "rds-$(basename "$cert" .pem)" \
-        -file "$cert" -keystore /app/certs/rds-truststore.p12 \
-        -storetype PKCS12 -storepass changeit; \
-    done; \
-    rm -f /tmp/rds-bundle.pem /tmp/rds-cert-*.pem
+COPY --from=rds-certs /app/certs /app/certs
 
 EXPOSE 8080
 

--- a/backend/src/main/java/org/danteplanner/backend/shared/gtid/GtidCookie.java
+++ b/backend/src/main/java/org/danteplanner/backend/shared/gtid/GtidCookie.java
@@ -1,6 +1,9 @@
 package org.danteplanner.backend.shared.gtid;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
 
 import org.springframework.http.ResponseCookie;
 
@@ -8,6 +11,10 @@ import org.springframework.http.ResponseCookie;
  * Builds the read-your-writes GTID cookie emitted via the {@code Set-Cookie} header.
  * The cookie carries the client's last-written GTID so subsequent reads can be routed
  * for causal consistency; a caught-up read clears it.
+ *
+ * <p>The value is Base64url-encoded: a raw GTID set is not cookie-safe, because a set
+ * spanning multiple source UUIDs is comma-separated and RFC 6265 forbids commas in
+ * cookie values.</p>
  */
 public final class GtidCookie {
 
@@ -20,11 +27,35 @@ public final class GtidCookie {
     }
 
     public static ResponseCookie of(String gtid) {
-        return base(gtid).build();
+        return base(encode(gtid)).build();
     }
 
     public static ResponseCookie cleared() {
         return base("").maxAge(Duration.ZERO).build();
+    }
+
+    /**
+     * Decodes a cookie value produced by {@link #of(String)} back into the raw GTID set.
+     *
+     * <p>Returns empty for blank or undecodable values so a tampered cookie degrades to
+     * "no cookie" rather than an error.</p>
+     */
+    public static Optional<String> decode(String cookieValue) {
+        if (cookieValue == null || cookieValue.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            String gtid = new String(
+                    Base64.getUrlDecoder().decode(cookieValue), StandardCharsets.UTF_8);
+            return gtid.isBlank() ? Optional.empty() : Optional.of(gtid);
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private static String encode(String gtid) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(gtid.getBytes(StandardCharsets.UTF_8));
     }
 
     private static ResponseCookie.ResponseCookieBuilder base(String value) {

--- a/backend/src/main/java/org/danteplanner/backend/shared/gtid/GtidCookieFilter.java
+++ b/backend/src/main/java/org/danteplanner/backend/shared/gtid/GtidCookieFilter.java
@@ -47,7 +47,9 @@ public class GtidCookieFilter extends OncePerRequestFilter {
 
     private void handleRead(HttpServletRequest request, HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
-        String gtid = readCookie(request);
+        String gtid = Optional.ofNullable(readCookie(request))
+                .flatMap(GtidCookie::decode)
+                .orElse(null);
         if (gtid == null) {
             filterChain.doFilter(request, response);
             return;

--- a/backend/src/test/java/org/danteplanner/backend/shared/gtid/GtidCookieFilterTest.java
+++ b/backend/src/test/java/org/danteplanner/backend/shared/gtid/GtidCookieFilterTest.java
@@ -51,7 +51,7 @@ class GtidCookieFilterTest {
     @Test
     void readGet_WhenCookieCaughtUp_ClearsCookieAndDoesNotPin() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/planners");
-        request.setCookies(new Cookie(GtidCookie.NAME, GTID));
+        request.setCookies(new Cookie(GtidCookie.NAME, GtidCookie.of(GTID).getValue()));
         MockHttpServletResponse response = new MockHttpServletResponse();
         when(readGate.isCaughtUp(GTID)).thenReturn(true);
 
@@ -71,7 +71,7 @@ class GtidCookieFilterTest {
     @Test
     void readGet_WhenCookieNotCaughtUp_PinsPrimaryRetainsCookieAndClearsPin() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/planners");
-        request.setCookies(new Cookie(GtidCookie.NAME, GTID));
+        request.setCookies(new Cookie(GtidCookie.NAME, GtidCookie.of(GTID).getValue()));
         MockHttpServletResponse response = new MockHttpServletResponse();
         when(readGate.isCaughtUp(GTID)).thenReturn(false);
 
@@ -89,7 +89,7 @@ class GtidCookieFilterTest {
     @Test
     void readGet_WhenNotCaughtUpAndChainThrows_StillClearsPin() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/planners");
-        request.setCookies(new Cookie(GtidCookie.NAME, GTID));
+        request.setCookies(new Cookie(GtidCookie.NAME, GtidCookie.of(GTID).getValue()));
         MockHttpServletResponse response = new MockHttpServletResponse();
         when(readGate.isCaughtUp(GTID)).thenReturn(false);
         RuntimeException boom = new RuntimeException("chain blew up");
@@ -119,10 +119,40 @@ class GtidCookieFilterTest {
 
         assertThat(response.getHeaders(HttpHeaders.SET_COOKIE))
                 .anySatisfy(header -> assertThat(header)
-                        .contains(GtidCookie.NAME + "=" + GTID)
+                        .contains(GtidCookie.NAME + "=" + GtidCookie.of(GTID).getValue())
                         .contains("HttpOnly")
                         .contains("Secure")
                         .contains("SameSite=Lax"));
+        verifyNoInteractions(readGate);
+    }
+
+    @Test
+    void write_WhenCaptureHasMultiUuidGtidSet_SetsCookieWithoutError() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/api/planners");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        String gtidSet = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100,"
+                + "8f9e0d1c-2b3a-4c5d-6e7f-8a9b0c1d2e3f:1-50";
+        when(writeCapture.pollCapturedGtid()).thenReturn(Optional.of(gtidSet));
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getHeaders(HttpHeaders.SET_COOKIE))
+                .anySatisfy(header -> assertThat(header)
+                        .contains(GtidCookie.NAME + "=" + GtidCookie.of(gtidSet).getValue()));
+    }
+
+    @Test
+    void readGet_WhenCookieValueUndecodable_TreatedAsAbsent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/planners");
+        request.setCookies(new Cookie(GtidCookie.NAME, "not*base64url*value"));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        try (MockedStatic<ReadOnlyRoutingDataSource> ds = mockStatic(ReadOnlyRoutingDataSource.class)) {
+            filter.doFilter(request, response, new MockFilterChain());
+
+            ds.verify(() -> ReadOnlyRoutingDataSource.pinTo(any()), never());
+        }
+
         verifyNoInteractions(readGate);
     }
 }

--- a/backend/src/test/java/org/danteplanner/backend/shared/gtid/GtidCookieTest.java
+++ b/backend/src/test/java/org/danteplanner/backend/shared/gtid/GtidCookieTest.java
@@ -10,17 +10,38 @@ import org.springframework.http.ResponseCookie;
 class GtidCookieTest {
 
     @Test
-    void of_WithGtid_CarriesHttpOnlySecureSameSiteLaxValue() {
+    void of_WithGtid_CarriesHttpOnlySecureSameSiteLaxRoundTrippableValue() {
         String gtid = "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5";
 
         ResponseCookie cookie = GtidCookie.of(gtid);
 
         assertThat(cookie.getName()).isEqualTo("ryw_gtid");
-        assertThat(cookie.getValue()).isEqualTo(gtid);
+        assertThat(GtidCookie.decode(cookie.getValue())).contains(gtid);
         assertThat(cookie.isHttpOnly()).isTrue();
         assertThat(cookie.isSecure()).isTrue();
         assertThat(cookie.getSameSite()).isEqualTo("Lax");
         assertThat(cookie.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    void of_WithMultiUuidGtidSet_ProducesCookieSafeValue() {
+        String gtidSet = "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-100,"
+                + "8f9e0d1c-2b3a-4c5d-6e7f-8a9b0c1d2e3f:1-50";
+
+        ResponseCookie cookie = GtidCookie.of(gtidSet);
+
+        assertThat(cookie.getValue()).doesNotContain(",", ";", "\"", "\\", " ");
+        assertThat(GtidCookie.decode(cookie.getValue())).contains(gtidSet);
+    }
+
+    @Test
+    void decode_WithBlankValue_ReturnsEmpty() {
+        assertThat(GtidCookie.decode("")).isEmpty();
+    }
+
+    @Test
+    void decode_WithNonBase64Value_ReturnsEmpty() {
+        assertThat(GtidCookie.decode("3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5,tampered")).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
GtidWriteCapture ships @@gtid_executed verbatim into the ryw_gtid
cookie, but a GTID set spanning multiple source UUIDs is
comma-separated and RFC 6265 forbids commas in cookie values, so
ResponseCookie validation threw on every Seoul write response after
the handler had already committed. Clients never received the new
syncVersion and every save, publish, and delete cascaded into
permanent 409 conflicts.

Encode the set on write and decode on read; blank or undecodable
cookie values degrade to "no cookie" instead of erroring, so a
tampered cookie can never break a committed response again.