### PR TITLE
Observability: exporter TLS, series budget, config hot-reload

### DIFF
--- a/deploy/base/mysqld-exporter.yaml
+++ b/deploy/base/mysqld-exporter.yaml
@@ -87,3 +87,6 @@ spec:
     - secretKey: primary-endpoint
       remoteRef:
         key: danteplanner/mysqld-exporter/primary-endpoint
+    - secretKey: replica-endpoint
+      remoteRef:
+        key: danteplanner/mysqld-exporter/replica-endpoint

--- a/deploy/base/prometheus.yaml
+++ b/deploy/base/prometheus.yaml
@@ -141,6 +141,8 @@ spec:
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.retention.time=7d
             - --enable-feature=expand-external-labels
+            # Required by the config-reloader sidecar's POST /-/reload.
+            - --web.enable-lifecycle
           ports:
             - name: web
               containerPort: 9090
@@ -158,6 +160,20 @@ spec:
               memory: 256Mi
             limits:
               memory: 512Mi
+        - name: config-reloader
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.76.0
+          args:
+            - --watched-dir=/etc/prometheus
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
       volumes:
         - name: config
           configMap:

--- a/deploy/overlays/seoul/mysqld-endpoint-patch.yaml
+++ b/deploy/overlays/seoul/mysqld-endpoint-patch.yaml
@@ -8,5 +8,9 @@ spec:
       containers:
         - name: mysqld-exporter
           env:
+            # Must dial the name on the server certificate, not the Route53 alias.
             - name: MYSQLD_ADDRESS
-              value: mysql-replica.seoul.danteplanner.internal:3306
+              valueFrom:
+                secretKeyRef:
+                  name: mysqld-exporter-dsn
+                  key: replica-endpoint


### PR DESCRIPTION
## Deploy-affecting changes

- **mysqld_exporter over TLS**: RDS enforces require_secure_transport; the exporter now verifies against the committed public RDS CA bundle. Seoul dials the replica's certificate hostname (delivered via ExternalSecret) instead of the Route53 alias, which fails x509 hostname verification.
- **Remote-write series budget**: a write_relabel keep-list ships only the series cloud alerts and dashboards query; recording rules pre-aggregate the request-latency histogram per endpoint; scrape interval moves to 60s (matches the plan's 1-DPM pricing unit; every alert rides a 5-15m pending period). Local 7d TSDB keeps full fidelity.
- **Prometheus config hot-reload**: a config-reloader sidecar POSTs /-/reload when the mounted ConfigMap changes — config applies seconds after sync, without a restart or TSDB wipe.
- **redis_exporter** per instance (auth + ratelimit) under their own job labels.
- **Percentile histograms** on http.server.requests (backend property; raw buckets stay local-only, aggregates ship).
- **Grafana datasource IAM as code**: the read-only CloudWatch user and its policy adopted into terraform/secrets via import blocks (logs read statements added).

## Post-merge operational steps

1. Ensure the danteplanner/mysqld-exporter/replica-endpoint secret exists in both regions before ArgoCD syncs (ExternalSecret references it fleet-wide).
2. One rollout restart of deploy/prometheus per region — the last config-change restart; the reloader takes over from there.
3. terraform -chdir=terraform/secrets apply (review the IAM import plan).

Expected effects: Seoul mysql_up flips to 1; Grafana active series decay to roughly 5-7k within the hour; endpoint latency percentiles populate once recording rules evaluate.