### PR TITLE
Observability: Loki log pipeline, provisioning kit, etcd convergence

### DIFF
--- a/deploy/base/alloy-logs.yaml
+++ b/deploy/base/alloy-logs.yaml
@@ -1,0 +1,142 @@
+# Ships pod logs to Grafana Cloud Loki via the kubelet API (no hostPath), labeled
+# with the per-region cluster identity. Loki credentials (stack logs id + token
+# with logs:write) arrive via Secrets Manager -> ESO -> file mounts — the logs id
+# is account-identifying and this repo is public, so only the shared push URL is
+# committed. One Deployment per cluster on the data node, like the other observers.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy-logs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy-logs
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "services", "endpoints", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy-logs
+subjects:
+  - kind: ServiceAccount
+    name: alloy-logs
+    namespace: danteplanner
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-loki-write
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: grafana-loki-write
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: danteplanner/grafana/loki-username
+    - secretKey: password
+      remoteRef:
+        key: danteplanner/grafana/loki-password
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-logs-config
+data:
+  config.alloy: |
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+    }
+
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pods.output
+      forward_to = [loki.write.grafana_cloud.receiver]
+    }
+
+    loki.write "grafana_cloud" {
+      endpoint {
+        url = "https://logs-prod-036.grafana.net/loki/api/v1/push"
+        basic_auth {
+          username_file = "/etc/alloy/loki/username"
+          password_file = "/etc/alloy/loki/password"
+        }
+      }
+      external_labels = {
+        cluster = env("CLUSTER_NAME"),
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-logs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alloy-logs
+  template:
+    metadata:
+      labels:
+        app: alloy-logs
+    spec:
+      serviceAccountName: alloy-logs
+      nodeSelector:
+        role: data
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.5.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+          env:
+            - name: CLUSTER_NAME
+              value: placeholder
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: loki-auth
+              mountPath: /etc/alloy/loki
+              readOnly: true
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-logs-config
+        - name: loki-auth
+          secret:
+            secretName: grafana-loki-write

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - kube-state-metrics.yaml
   - mysqld-exporter.yaml
   - redis-exporter.yaml
+  - alloy-logs.yaml
   - node-exporter.yaml
 
 configMapGenerator:

--- a/deploy/grafana/create-staleness-rules.sh
+++ b/deploy/grafana/create-staleness-rules.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# create rule M (per-cluster staleness meta) — ONLY after
+# remote_write data is confirmed flowing, because an absent-detector fires on
+# the pre-wiring absence itself.
+# Usage: GRAFANA_URL=... GRAFANA_TOKEN=... h2-create-rule-m.sh
+set -euo pipefail
+: "${GRAFANA_URL:?set GRAFANA_URL}"
+: "${GRAFANA_TOKEN:?set GRAFANA_TOKEN}"
+auth=(-H "Authorization: Bearer ${GRAFANA_TOKEN}" -H "Content-Type: application/json")
+noprov=(-H "X-Disable-Provenance: true")
+
+echo "== pre-flight: is up{cluster=...} actually arriving in Grafana Cloud?"
+for c in oregon seoul; do
+  resp=$(curl -s -w '\n%{http_code}' "${auth[@]}" \
+    "${GRAFANA_URL}/api/datasources/proxy/uid/grafanacloud-prom/api/v1/query?query=count(up%7Bcluster%3D%22${c}%22%7D)")
+  code=${resp##*$'\n'}; body=${resp%$'\n'*}
+  if [ "$code" != 200 ]; then
+    echo "   PRE-FLIGHT QUERY FAILED for cluster=${c} (HTTP ${code}) — this is a query/permission"
+    echo "   problem, NOT evidence of missing data. Response:"
+    printf '%s\n' "$body" | head -c 400; echo
+    exit 1
+  fi
+  n=$(printf '%s' "$body" | jq -r '.data.result[0].value[1] // "MISSING"')
+  echo "   cluster=${c}: ${n} up-series"
+  if [ "$n" = MISSING ] || [ "$n" = 0 ]; then
+    echo "ABORT: query succeeded but returned no series for cluster=${c} —"
+    echo "creating M now would page immediately. Raw response:"
+    printf '%s\n' "$body" | head -c 400; echo
+    exit 1
+  fi
+done
+
+FOLDER_UID=$(curl -s "${auth[@]}" "${GRAFANA_URL}/api/folders" |
+  jq -r '[.[] | select(.title=="danteplanner-alerts")][0].uid // empty')
+[ -n "$FOLDER_UID" ] || { echo "folder danteplanner-alerts not found"; exit 1; }
+
+for c in oregon seoul; do
+  resp=$(jq -n --arg ds grafanacloud-prom --arg folder "$FOLDER_UID" --arg c "$c" '
+    { title:("staleness-meta-" + $c), ruleGroup:"cluster-rules", folderUID:$folder,
+      condition:"C", for:"2m", noDataState:"OK", execErrState:"OK",
+      data:[
+        {refId:"A", relativeTimeRange:{from:600,to:0}, datasourceUid:$ds,
+         model:{refId:"A", expr:("absent_over_time(up{cluster=\"" + $c + "\"}[10m])"), instant:true}},
+        {refId:"B", relativeTimeRange:{from:0,to:0}, datasourceUid:"__expr__",
+         model:{refId:"B", type:"reduce", reducer:"last", expression:"A",
+                datasource:{type:"__expr__",uid:"__expr__"}}},
+        {refId:"C", relativeTimeRange:{from:0,to:0}, datasourceUid:"__expr__",
+         model:{refId:"C", type:"threshold", expression:"B",
+                conditions:[{evaluator:{type:"gt",params:[0]}}],
+                datasource:{type:"__expr__",uid:"__expr__"}}}]}' |
+    curl -s -w '\n%{http_code}' "${auth[@]}" "${noprov[@]}" -X POST \
+      "${GRAFANA_URL}/api/v1/provisioning/alert-rules" -d @-)
+  code=${resp##*$'\n'}; body=${resp%$'\n'*}
+  if [ "$code" = 201 ]; then
+    printf '%s' "$body" | jq -r '"   created: " + .title + "  (uid " + .uid + ")"'
+  else
+    echo "   FAILED staleness-meta-${c} (HTTP ${code}): ${body}"; exit 1
+  fi
+done
+echo "done — staleness detection is live (fires when a cluster stops remote-writing for 10m)"

--- a/deploy/grafana/drill-alert-delivery.sh
+++ b/deploy/grafana/drill-alert-delivery.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#  through-policy drill — creates a scratch always-firing rule via the
+# provisioning API, lets ONE firing route through the Default policy to
+# alert-dual-channel (Discord AND Slack), then deletes the rule.
+# Usage: GRAFANA_URL=https://<slug>.grafana.net GRAFANA_TOKEN=<editor token> g-drill-inv6.sh
+set -euo pipefail
+: "${GRAFANA_URL:?set GRAFANA_URL (no trailing slash)}"
+: "${GRAFANA_TOKEN:?set GRAFANA_TOKEN}"
+auth=(-H "Authorization: Bearer ${GRAFANA_TOKEN}" -H "Content-Type: application/json")
+noprov=(-H "X-Disable-Provenance: true")
+
+FOLDER_UID=$(curl -s "${auth[@]}" "${GRAFANA_URL}/api/folders" |
+  jq -r '[.[] | select(.title=="danteplanner-alerts")][0].uid // empty')
+[ -n "$FOLDER_UID" ] || { echo "folder danteplanner-alerts not found — run import-alert-rules.sh first"; exit 1; }
+
+echo "== creating scratch rule inv6-drill (fires immediately; vector(1) needs no stored data)"
+resp=$(jq -n --arg ds grafanacloud-prom --arg folder "$FOLDER_UID" '
+  { title:"inv6-drill", ruleGroup:"cluster-rules", folderUID:$folder,
+    condition:"C", for:"0s", noDataState:"OK", execErrState:"OK",
+    data:[
+      {refId:"A", relativeTimeRange:{from:600,to:0}, datasourceUid:$ds,
+       model:{refId:"A", expr:"vector(1)", instant:true}},
+      {refId:"B", relativeTimeRange:{from:0,to:0}, datasourceUid:"__expr__",
+       model:{refId:"B", type:"reduce", reducer:"last", expression:"A",
+              datasource:{type:"__expr__",uid:"__expr__"}}},
+      {refId:"C", relativeTimeRange:{from:0,to:0}, datasourceUid:"__expr__",
+       model:{refId:"C", type:"threshold", expression:"B",
+              conditions:[{evaluator:{type:"gt",params:[0]}}],
+              datasource:{type:"__expr__",uid:"__expr__"}}}]}' |
+  curl -s -w '\n%{http_code}' "${auth[@]}" "${noprov[@]}" -X POST \
+    "${GRAFANA_URL}/api/v1/provisioning/alert-rules" -d @-)
+code=${resp##*$'\n'}; body=${resp%$'\n'*}
+[ "$code" = 201 ] || { echo "create failed (HTTP $code): $body"; exit 1; }
+UID=$(printf '%s' "$body" | jq -r .uid)
+echo "   created uid $UID — the group evaluates every ~1m; the firing then routes through"
+echo "   the Default policy. WATCH BOTH channels now (Discord #alerts AND Slack)."
+echo
+read -rp "Did the SAME 'inv6-drill' firing arrive in BOTH Discord and Slack? [y/n] " seen
+
+echo "== deleting scratch rule"
+del=$(curl -s -o /dev/null -w '%{http_code}' "${auth[@]}" "${noprov[@]}" -X DELETE \
+  "${GRAFANA_URL}/api/v1/provisioning/alert-rules/${UID}")
+echo "   delete HTTP ${del} (204 = gone)"
+
+if [ "$seen" = y ]; then
+  echo "DRILL PASS — record: one firing, both channels, via Default policy -> alert-dual-channel."
+  echo "This proves the through-policy delivery (a per-rule firing proof"
+  echo "can ride a real incident or a later manual drill)."
+else
+  echo "DRILL FAIL — check: Notification policies Default -> alert-dual-channel (no nested routes),"
+  echo "then contact-point Test to isolate webhook vs routing. Re-run this script after fixing."
+  exit 1
+fi

--- a/deploy/grafana/fleet-dashboard.json
+++ b/deploy/grafana/fleet-dashboard.json
@@ -1,0 +1,1215 @@
+{
+ "title": "DantePlanner Fleet Health",
+ "uid": "danteplanner-fleet",
+ "timezone": "browser",
+ "refresh": "1m",
+ "time": {
+  "from": "now-6h",
+  "to": "now"
+ },
+ "templating": {
+  "list": [
+   {
+    "name": "DS_PROM",
+    "type": "datasource",
+    "query": "prometheus",
+    "label": "Prometheus"
+   },
+   {
+    "name": "DS_CW",
+    "type": "datasource",
+    "query": "cloudwatch",
+    "label": "CloudWatch"
+   },
+   {
+    "name": "DS_LOKI",
+    "type": "datasource",
+    "query": "loki",
+    "label": "Loki",
+    "regex": "/-logs$/"
+   }
+  ]
+ },
+ "annotations": {
+  "list": [
+   {
+    "name": "Deploys",
+    "datasource": {
+     "type": "datasource",
+     "uid": "-- Grafana --"
+    },
+    "enable": true,
+    "iconColor": "purple",
+    "target": {
+     "type": "tags",
+     "tags": [
+      "deploy"
+     ],
+     "limit": 100
+    }
+   }
+  ]
+ },
+ "panels": [
+  {
+   "id": 1,
+   "type": "stat",
+   "title": "Healthy scrape targets",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 0,
+    "w": 6,
+    "h": 6
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "count(up == 1) by (cluster)",
+     "legendFormat": "{{cluster}}",
+     "instant": true
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 7
+       },
+       {
+        "color": "green",
+        "value": 9
+       }
+      ]
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 2,
+   "type": "stat",
+   "title": "Nodes Ready",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 6,
+    "y": 0,
+    "w": 6,
+    "h": 6
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 1) by (cluster)",
+     "legendFormat": "{{cluster}}",
+     "instant": true
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 3
+       }
+      ]
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 3,
+   "type": "stat",
+   "title": "Backend daemonset ready pods",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 12,
+    "y": 0,
+    "w": 6,
+    "h": 6
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "kube_daemonset_status_number_ready{daemonset=\"backend\"}",
+     "legendFormat": "{{cluster}}",
+     "instant": true
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 4,
+   "type": "stat",
+   "title": "etcd snapshot age (hours)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 18,
+    "y": 0,
+    "w": 6,
+    "h": 6
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "(time() - max by (cluster)(kube_etcd_snapshot_creation_timestamp_seconds)) / 3600",
+     "legendFormat": "{{cluster}}",
+     "instant": true
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "h",
+     "decimals": 1,
+     "thresholds": {
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 13
+       },
+       {
+        "color": "red",
+        "value": 18
+       }
+      ]
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 5,
+   "type": "timeseries",
+   "title": "Scrape targets over time",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 6,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(up) by (cluster, job)",
+     "legendFormat": "{{cluster}}/{{job}}"
+    }
+   ]
+  },
+  {
+   "id": 6,
+   "type": "timeseries",
+   "title": "Containers stuck waiting (CrashLoop / ImagePull)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 12,
+    "y": 6,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(kube_pod_container_status_waiting_reason{reason=~\"CrashLoopBackOff|ImagePullBackOff\"}) by (cluster, reason)",
+     "legendFormat": "{{cluster}} {{reason}}"
+    }
+   ]
+  },
+  {
+   "id": 7,
+   "type": "timeseries",
+   "title": "TSDB head series (cardinality budget)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 14,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "prometheus_tsdb_head_series",
+     "legendFormat": "{{cluster}}"
+    }
+   ]
+  },
+  {
+   "id": 8,
+   "type": "timeseries",
+   "title": "remote_write failure rate",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 12,
+    "y": 14,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "rate(prometheus_remote_storage_samples_failed_total[5m])",
+     "legendFormat": "{{cluster}}"
+    }
+   ]
+  },
+  {
+   "id": 10,
+   "type": "row",
+   "title": "Application",
+   "gridPos": {
+    "x": 0,
+    "y": 22,
+    "w": 24,
+    "h": 1
+   },
+   "panels": []
+  },
+  {
+   "id": 11,
+   "type": "timeseries",
+   "title": "HTTP request rate (req/min) by status",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 23,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(rate(http_server_requests_seconds_count[5m])) by (cluster, status) * 60",
+     "legendFormat": "{{cluster}} {{status}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "suffix:req/min",
+     "decimals": 1
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 12,
+   "type": "table",
+   "title": "Slowest endpoints \u2014 p50 / p90 / p99 per cluster (SSE excluded)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 23,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.50, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"oregon\"}[$__range])) > 0"
+    },
+    {
+     "refId": "B",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.50, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"seoul\"}[$__range])) > 0"
+    },
+    {
+     "refId": "C",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.90, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"oregon\"}[$__range])) > 0"
+    },
+    {
+     "refId": "D",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.90, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"seoul\"}[$__range])) > 0"
+    },
+    {
+     "refId": "E",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.99, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"oregon\"}[$__range])) > 0"
+    },
+    {
+     "refId": "F",
+     "instant": true,
+     "format": "table",
+     "expr": "histogram_quantile(0.99, avg_over_time(uri:http_server_requests_seconds_bucket:rate5m{cluster=\"seoul\"}[$__range])) > 0"
+    },
+    {
+     "refId": "G",
+     "instant": true,
+     "format": "table",
+     "expr": "sum by (uri) (avg_over_time(uri:http_server_requests_seconds_count:rate5m[$__range])) * $__range_s > 0"
+    }
+   ],
+   "transformations": [
+    {
+     "id": "joinByField",
+     "options": {
+      "byField": "uri",
+      "mode": "outer"
+     }
+    },
+    {
+     "id": "organize",
+     "options": {
+      "excludeByName": {
+       "Time": true,
+       "Time 1": true,
+       "Time 2": true,
+       "Time 3": true,
+       "Time 4": true,
+       "Time 5": true,
+       "Time 6": true,
+       "Time 7": true,
+       "cluster": true,
+       "cluster 1": true,
+       "cluster 2": true,
+       "cluster 3": true,
+       "cluster 4": true,
+       "cluster 5": true,
+       "cluster 6": true,
+       "cluster 7": true
+      },
+      "renameByName": {
+       "Value #A": "p50 (oregon)",
+       "Value #B": "p50 (seoul)",
+       "Value #C": "p90 (oregon)",
+       "Value #D": "p90 (seoul)",
+       "Value #E": "p99 (oregon)",
+       "Value #F": "p99 (seoul)",
+       "Value #G": "requests"
+      },
+      "indexByName": {
+       "uri": 0,
+       "p50 (oregon)": 1,
+       "p50 (seoul)": 2,
+       "p90 (oregon)": 3,
+       "p90 (seoul)": 4,
+       "p99 (oregon)": 5,
+       "p99 (seoul)": 6,
+       "requests": 7
+      }
+     }
+    },
+    {
+     "id": "sortBy",
+     "options": {
+      "fields": {},
+      "sort": [
+       {
+        "field": "p99 (oregon)",
+        "desc": true
+       }
+      ]
+     }
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "decimals": 3
+    },
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byRegexp",
+       "options": "p\\d+ \\(.*\\)"
+      },
+      "properties": [
+       {
+        "id": "unit",
+        "value": "suffix: s"
+       },
+       {
+        "id": "decimals",
+        "value": 3
+       }
+      ]
+     },
+     {
+      "matcher": {
+       "id": "byName",
+       "options": "requests"
+      },
+      "properties": [
+       {
+        "id": "decimals",
+        "value": 0
+       }
+      ]
+     }
+    ]
+   }
+  },
+  {
+   "id": 13,
+   "type": "timeseries",
+   "title": "HTTP 5xx rate (req/min)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 16,
+    "y": 23,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(rate(http_server_requests_seconds_count{status=~\"5..\"}[5m])) by (cluster, status) * 60",
+     "legendFormat": "{{cluster}} {{status}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 0.1
+       }
+      ]
+     },
+     "unit": "suffix:req/min"
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 14,
+   "type": "timeseries",
+   "title": "Log events WARN / ERROR (count)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 31,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(increase(logback_events_total{level=~\"warn|error\"}[$__interval])) by (cluster, level)",
+     "legendFormat": "{{cluster}} {{level}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "none",
+     "decimals": 0,
+     "custom": {
+      "drawStyle": "bars",
+      "fillOpacity": 60
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 15,
+   "type": "timeseries",
+   "title": "Hikari connections (active / pending) by pool",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 31,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(hikaricp_connections_active) by (cluster, pool)",
+     "legendFormat": "{{cluster}} {{pool}} active"
+    },
+    {
+     "refId": "B",
+     "expr": "sum(hikaricp_connections_pending) by (cluster, pool)",
+     "legendFormat": "{{cluster}} {{pool}} pending"
+    }
+   ]
+  },
+  {
+   "id": 16,
+   "type": "timeseries",
+   "title": "JVM heap used / GC pause rate",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 16,
+    "y": 31,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(jvm_memory_used_bytes{area=\"heap\"}) by (cluster)",
+     "legendFormat": "{{cluster}} heap"
+    },
+    {
+     "refId": "B",
+     "expr": "sum(rate(jvm_gc_pause_seconds_sum[5m])) by (cluster) * 1000",
+     "legendFormat": "{{cluster}} gc"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes"
+    },
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byFrameRefID",
+       "options": "B"
+      },
+      "properties": [
+       {
+        "id": "unit",
+        "value": "ms"
+       }
+      ]
+     }
+    ]
+   }
+  },
+  {
+   "id": 17,
+   "type": "timeseries",
+   "title": "JVM threads by state",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 39,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(jvm_threads_states_threads) by (cluster, state)",
+     "legendFormat": "{{cluster}} {{state}}"
+    }
+   ]
+  },
+  {
+   "id": 18,
+   "type": "timeseries",
+   "title": "Replica misses promoted to primary (read-consistency gate)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 39,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(rate(replica_miss_promoted_total[5m])) by (cluster)",
+     "legendFormat": "{{cluster}}"
+    }
+   ]
+  },
+  {
+   "id": 40,
+   "type": "row",
+   "title": "Redis",
+   "gridPos": {
+    "x": 0,
+    "y": 47,
+    "w": 24,
+    "h": 1
+   },
+   "panels": []
+  },
+  {
+   "id": 41,
+   "type": "timeseries",
+   "title": "Redis memory used (ratio where maxmemory set)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 48,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "redis_memory_used_bytes",
+     "legendFormat": "{{cluster}} {{job}} used"
+    },
+    {
+     "refId": "B",
+     "expr": "redis_memory_used_bytes / (redis_memory_max_bytes > 0)",
+     "legendFormat": "{{cluster}} {{job}} ratio"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes"
+    },
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byFrameRefID",
+       "options": "B"
+      },
+      "properties": [
+       {
+        "id": "unit",
+        "value": "percentunit"
+       },
+       {
+        "id": "custom.axisPlacement",
+        "value": "right"
+       }
+      ]
+     }
+    ]
+   }
+  },
+  {
+   "id": 42,
+   "type": "timeseries",
+   "title": "Memory fragmentation ratio",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 48,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "redis_mem_fragmentation_ratio",
+     "legendFormat": "{{cluster}} {{job}}"
+    }
+   ]
+  },
+  {
+   "id": 43,
+   "type": "timeseries",
+   "title": "Keyspace hit ratio",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 16,
+    "y": 48,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "rate(redis_keyspace_hits_total[5m]) / clamp_min(rate(redis_keyspace_hits_total[5m]) + rate(redis_keyspace_misses_total[5m]), 1e-9)",
+     "legendFormat": "{{cluster}} {{job}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit",
+     "max": 1
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 44,
+   "type": "timeseries",
+   "title": "Clients (connected / blocked)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 56,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "redis_connected_clients",
+     "legendFormat": "{{cluster}} {{job}} connected"
+    },
+    {
+     "refId": "B",
+     "expr": "redis_blocked_clients",
+     "legendFormat": "{{cluster}} {{job}} blocked"
+    }
+   ]
+  },
+  {
+   "id": 45,
+   "type": "timeseries",
+   "title": "Keys expiring (token-accumulation trend)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 56,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum(redis_db_keys_expiring) by (cluster, job)",
+     "legendFormat": "{{cluster}} {{job}}"
+    }
+   ]
+  },
+  {
+   "id": 46,
+   "type": "timeseries",
+   "title": "Replication offset (auth, cross-region delta)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 16,
+    "y": 56,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "redis_master_repl_offset{job=\"redis-auth\"}",
+     "legendFormat": "{{cluster}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes"
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 20,
+   "type": "row",
+   "title": "Database",
+   "gridPos": {
+    "x": 0,
+    "y": 64,
+    "w": 24,
+    "h": 1
+   },
+   "panels": []
+  },
+  {
+   "id": 21,
+   "type": "timeseries",
+   "title": "Slow queries rate",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 65,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "rate(mysql_global_status_slow_queries[5m])",
+     "legendFormat": "{{cluster}}"
+    }
+   ]
+  },
+  {
+   "id": 24,
+   "type": "timeseries",
+   "title": "RDS connections \u2014 primary and replica side by side",
+   "datasource": {
+    "type": "cloudwatch",
+    "uid": "${DS_CW}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 73,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "namespace": "AWS/RDS",
+     "metricName": "DatabaseConnections",
+     "statistic": "Maximum",
+     "period": "60",
+     "region": "us-west-2",
+     "matchExact": false,
+     "dimensions": {
+      "DBInstanceIdentifier": "*"
+     },
+     "label": "us-west-2 ${PROP('Dim.DBInstanceIdentifier')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    },
+    {
+     "refId": "B",
+     "namespace": "AWS/RDS",
+     "metricName": "DatabaseConnections",
+     "statistic": "Maximum",
+     "period": "60",
+     "region": "ap-northeast-2",
+     "matchExact": false,
+     "dimensions": {
+      "DBInstanceIdentifier": "*"
+     },
+     "label": "ap-northeast-2 ${PROP('Dim.DBInstanceIdentifier')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    }
+   ]
+  },
+  {
+   "id": 25,
+   "type": "timeseries",
+   "title": "RDS FreeableMemory",
+   "datasource": {
+    "type": "cloudwatch",
+    "uid": "${DS_CW}"
+   },
+   "gridPos": {
+    "x": 8,
+    "y": 73,
+    "w": 8,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "namespace": "AWS/RDS",
+     "metricName": "FreeableMemory",
+     "statistic": "Average",
+     "period": "300",
+     "region": "us-west-2",
+     "matchExact": false,
+     "dimensions": {
+      "DBInstanceIdentifier": "*"
+     },
+     "label": "us-west-2 ${PROP('Dim.DBInstanceIdentifier')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    },
+    {
+     "refId": "B",
+     "namespace": "AWS/RDS",
+     "metricName": "FreeableMemory",
+     "statistic": "Average",
+     "period": "300",
+     "region": "ap-northeast-2",
+     "matchExact": false,
+     "dimensions": {
+      "DBInstanceIdentifier": "*"
+     },
+     "label": "ap-northeast-2 ${PROP('Dim.DBInstanceIdentifier')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes"
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 26,
+   "type": "logs",
+   "title": "Slow query log (primary)",
+   "datasource": {
+    "type": "cloudwatch",
+    "uid": "${DS_CW}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 81,
+    "w": 24,
+    "h": 9
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "queryMode": "Logs",
+     "region": "us-west-2",
+     "logGroupNames": [
+      "/aws/rds/instance/danteplanner-mysql/slowquery"
+     ],
+     "expression": "fields @timestamp, @message | sort @timestamp desc | limit 50"
+    }
+   ]
+  },
+  {
+   "id": 27,
+   "type": "timeseries",
+   "title": "EC2 burstable CPU credits",
+   "datasource": {
+    "type": "cloudwatch",
+    "uid": "${DS_CW}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 90,
+    "w": 24,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "namespace": "AWS/EC2",
+     "metricName": "CPUCreditBalance",
+     "statistic": "Average",
+     "period": "300",
+     "region": "us-west-2",
+     "matchExact": false,
+     "dimensions": {
+      "InstanceId": "*"
+     },
+     "label": "us-west-2 ${PROP('Dim.InstanceId')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    },
+    {
+     "refId": "B",
+     "namespace": "AWS/EC2",
+     "metricName": "CPUCreditBalance",
+     "statistic": "Average",
+     "period": "300",
+     "region": "ap-northeast-2",
+     "matchExact": false,
+     "dimensions": {
+      "InstanceId": "*"
+     },
+     "label": "ap-northeast-2 ${PROP('Dim.InstanceId')}",
+     "queryMode": "Metrics",
+     "metricQueryType": 0,
+     "metricEditorMode": 0,
+     "expression": "",
+     "id": ""
+    }
+   ]
+  },
+  {
+   "id": 28,
+   "type": "logs",
+   "title": "Recent WARN / ERROR (application logs)",
+   "datasource": {
+    "type": "loki",
+    "uid": "${DS_LOKI}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 98,
+    "w": 24,
+    "h": 10
+   },
+   "options": {
+    "showTime": true,
+    "sortOrder": "Descending",
+    "wrapLogMessage": true
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "{namespace=\"danteplanner\"} | json | level=~\"WARN|ERROR\" | line_format \"{{.level}} {{.logger_name}} {{.message}}\""
+    }
+   ]
+  },
+  {
+   "id": 47,
+   "type": "timeseries",
+   "title": "Node memory occupation",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 0,
+    "y": 108,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+     "legendFormat": "{{cluster}} {{instance}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit",
+     "max": 1,
+     "thresholds": {
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 0.8
+       },
+       {
+        "color": "red",
+        "value": 0.9
+       }
+      ]
+     }
+    },
+    "overrides": []
+   }
+  },
+  {
+   "id": 48,
+   "type": "timeseries",
+   "title": "Node memory pressure (PSI, 10s avg)",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROM}"
+   },
+   "gridPos": {
+    "x": 12,
+    "y": 108,
+    "w": 12,
+    "h": 8
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "rate(node_pressure_memory_waiting_seconds_total[5m])",
+     "legendFormat": "{{cluster}} {{instance}}"
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit"
+    },
+    "overrides": []
+   }
+  }
+ ]
+}

--- a/deploy/grafana/import-alert-rules.sh
+++ b/deploy/grafana/import-alert-rules.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Provision the Grafana-managed alert rules via the provisioning API.
+# Staleness rules are provisioned separately by create-staleness-rules.sh once remote_write data flows.
+#
+# Usage:
+#   GRAFANA_URL=https://<slug>.grafana.net \
+#   GRAFANA_TOKEN=<service-account token, Editor role> \
+#   ETCD_INTERVAL=43200 \
+#   bash import-alert-rules.sh
+#
+# Live values (URL, token, interval) arrive only via env vars; nothing is written back.
+set -euo pipefail
+
+: "${GRAFANA_URL:?set GRAFANA_URL, e.g. https://yourslug.grafana.net (no trailing slash)}"
+: "${GRAFANA_TOKEN:?set GRAFANA_TOKEN (service-account token with Editor role)}"
+: "${ETCD_INTERVAL:?set ETCD_INTERVAL in seconds (k3s etcd-snapshot interval; k3s default 43200)}"
+
+auth=(-H "Authorization: Bearer ${GRAFANA_TOKEN}" -H "Content-Type: application/json")
+# X-Disable-Provenance keeps the rules editable in the UI afterwards; without it the
+# provisioning API marks them provenance=api and locks them against UI edits.
+noprov=(-H "X-Disable-Provenance: true")
+
+# Grafana Cloud stacks provision the hosted-Prometheus datasource with the stable
+# UID grafanacloud-prom; listing /api/datasources needs org Admin, so we don't try.
+DS_UID="${DS_UID:-grafanacloud-prom}"
+echo "== verifying datasource uid ${DS_UID}"
+code=$(curl -s -o /tmp/ds-check.json -w '%{http_code}' "${auth[@]}" \
+  "${GRAFANA_URL}/api/datasources/uid/${DS_UID}/health" -X GET)
+if [ "$code" != 200 ]; then
+  # Advisory only: rule provisioning needs alert-rule write, not datasources:query,
+  # so a 403 here does not predict the import's outcome.
+  echo "   note: datasource health check returned HTTP ${code} (continuing anyway;"
+  echo "   if rule creation 404s on the datasource, re-run with DS_UID=<uid> from"
+  echo "   the datasource page URL: /connections/datasources/edit/<uid>)"
+else
+  echo "   datasource ok"
+fi
+
+echo "== ensuring folder 'danteplanner-alerts'"
+folders=$(curl -s -w '\n%{http_code}' "${auth[@]}" "${GRAFANA_URL}/api/folders")
+code=${folders##*$'\n'}
+[ "$code" = 200 ] || { echo "   listing folders failed (HTTP ${code}): ${folders%$'\n'*}"; exit 1; }
+FOLDER_UID=$(printf '%s' "${folders%$'\n'*}" |
+  jq -r '[.[] | select(.title=="danteplanner-alerts")][0].uid // empty')
+if [ -z "$FOLDER_UID" ]; then
+  created=$(curl -s -w '\n%{http_code}' "${auth[@]}" -X POST "${GRAFANA_URL}/api/folders" \
+    -d '{"title":"danteplanner-alerts"}')
+  code=${created##*$'\n'}
+  [ "$code" = 200 ] || { echo "   creating folder failed (HTTP ${code}): ${created%$'\n'*}"; exit 1; }
+  FOLDER_UID=$(printf '%s' "${created%$'\n'*}" | jq -r .uid)
+fi
+echo "   folder uid: ${FOLDER_UID}"
+
+# post_rule TITLE FOR_DURATION PROMQL
+post_rule() {
+  local title=$1 for_dur=$2 expr=$3
+  jq -n \
+    --arg title "$title" --arg for "$for_dur" --arg expr "$expr" \
+    --arg ds "$DS_UID" --arg folder "$FOLDER_UID" '
+    {
+      title: $title, ruleGroup: "cluster-rules", folderUID: $folder,
+      condition: "C", for: $for, noDataState: "OK", execErrState: "OK",
+      data: [
+        { refId: "A", relativeTimeRange: {from: 600, to: 0}, datasourceUid: $ds,
+          model: {refId: "A", expr: $expr, instant: true} },
+        { refId: "B", relativeTimeRange: {from: 0, to: 0}, datasourceUid: "__expr__",
+          model: {refId: "B", type: "reduce", reducer: "last", expression: "A",
+                  datasource: {type: "__expr__", uid: "__expr__"}} },
+        { refId: "C", relativeTimeRange: {from: 0, to: 0}, datasourceUid: "__expr__",
+          model: {refId: "C", type: "threshold", expression: "B",
+                  conditions: [{evaluator: {type: "gt", params: [0]}}],
+                  datasource: {type: "__expr__", uid: "__expr__"}} }
+      ]
+    }' |
+  curl -s -w '\n%{http_code}' "${auth[@]}" "${noprov[@]}" -X POST \
+    "${GRAFANA_URL}/api/v1/provisioning/alert-rules" -d @- | {
+    resp=$(cat); code=${resp##*$'\n'}; body=${resp%$'\n'*}
+    if [ "$code" = 201 ]; then
+      printf '%s' "$body" | jq -r '"   created: " + .title + "  (uid " + .uid + ")"'
+    else
+      echo "   FAILED ${title} (HTTP ${code}): ${body}"; exit 1
+    fi
+  }
+}
+
+echo "== creating rules"
+post_rule "node-not-ready" "15m" \
+  'kube_node_status_condition{condition="Ready",status="true"} == 0'
+post_rule "backend-daemonset-unready" "5m" \
+  'kube_daemonset_status_number_ready{daemonset="backend"} == 0'
+post_rule "container-waiting-backoff" "10m" \
+  'kube_pod_container_status_waiting_reason{reason=~"CrashLoopBackOff|ImagePullBackOff"} == 1'
+post_rule "argocd-app-drift" "30m" \
+  'argocd_app_info{sync_status="OutOfSync"} == 1 or argocd_app_info{health_status="Degraded"} == 1'
+post_rule "eso-secret-not-ready" "15m" \
+  'externalsecret_status_condition{condition="Ready",status="False"} == 1'
+post_rule "etcd-snapshot-deadman" "1m" \
+  "(time() - kube_etcd_snapshot_creation_timestamp_seconds) > (1.5 * ${ETCD_INTERVAL})"
+
+echo "== done: 6 rules in folder danteplanner-alerts, group cluster-rules (1m interval)"
+echo "   All noDataState=OK — non-paging while their series are absent. Staleness rules are created separately by create-staleness-rules.sh."

--- a/deploy/grafana/import-fleet-dashboard.sh
+++ b/deploy/grafana/import-fleet-dashboard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Import (or update) the single-page fleet health dashboard.
+# Usage: GRAFANA_URL=... GRAFANA_TOKEN=... j-import-fleet-dashboard.sh
+set -euo pipefail
+: "${GRAFANA_URL:?set GRAFANA_URL}"
+: "${GRAFANA_TOKEN:?set GRAFANA_TOKEN}"
+auth=(-H "Authorization: Bearer ${GRAFANA_TOKEN}" -H "Content-Type: application/json")
+DIR=$(dirname "$0")
+
+FOLDER_UID=$(curl -s "${auth[@]}" "${GRAFANA_URL}/api/folders" |
+  jq -r '[.[] | select(.title=="danteplanner-dashboards")][0].uid // empty')
+[ -n "$FOLDER_UID" ] || { echo "folder danteplanner-dashboards not found — run i-import-dashboards.sh first"; exit 1; }
+
+resp=$(jq -n --slurpfile d "$DIR/fleet-dashboard.json" --arg f "$FOLDER_UID" \
+    '{dashboard: $d[0], folderUid: $f, overwrite: true}' |
+  curl -s -w '\n%{http_code}' "${auth[@]}" -X POST "${GRAFANA_URL}/api/dashboards/db" -d @-)
+code=${resp##*$'\n'}; body=${resp%$'\n'*}
+if [ "$code" = 200 ]; then
+  printf '%s' "$body" | jq -r '"imported: " + .url'
+else
+  echo "FAILED (HTTP $code): $(printf '%s' "$body" | head -c 300)"; exit 1
+fi

--- a/deploy/overlays/oregon/alloy-cluster-patch.yaml
+++ b/deploy/overlays/oregon/alloy-cluster-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-logs
+spec:
+  template:
+    spec:
+      containers:
+        - name: alloy
+          env:
+            - name: CLUSTER_NAME
+              value: oregon

--- a/deploy/overlays/oregon/kustomization.yaml
+++ b/deploy/overlays/oregon/kustomization.yaml
@@ -20,3 +20,4 @@ patches:
 - path: configmap-patch.yaml
 - path: prometheus-cluster-patch.yaml
 - path: mysqld-endpoint-patch.yaml
+- path: alloy-cluster-patch.yaml

--- a/deploy/overlays/seoul/alloy-cluster-patch.yaml
+++ b/deploy/overlays/seoul/alloy-cluster-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy-logs
+spec:
+  template:
+    spec:
+      containers:
+        - name: alloy
+          env:
+            - name: CLUSTER_NAME
+              value: seoul

--- a/deploy/overlays/seoul/kustomization.yaml
+++ b/deploy/overlays/seoul/kustomization.yaml
@@ -20,3 +20,4 @@ patches:
 - path: secretstore-region-patch.yaml
 - path: prometheus-cluster-patch.yaml
 - path: mysqld-endpoint-patch.yaml
+- path: alloy-cluster-patch.yaml

--- a/scripts/ops/fleet-metrics-verify.sh
+++ b/scripts/ops/fleet-metrics-verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Metrics probe battery against one region's local Prometheus.
+# Usage: f-verify-probes.sh <kubeconfig> <cluster-name oregon|seoul>
+set -euo pipefail
+KC=${1:?usage: f-verify-probes.sh <kubeconfig> <oregon|seoul>}
+NAME=${2:?cluster name required}
+k() { kubectl --kubeconfig "$KC" "$@"; }
+q() { k -n danteplanner exec deploy/prometheus -- \
+       wget -qO- --post-data "query=$1" http://localhost:9090/api/v1/query |
+       jq -r '.data.result[0].value[1] // "absent"'; }
+
+printf '%-46s %s\n' "PROBE ($NAME)" "RESULT"
+
+up_ksm=$(q 'up{job="kube-state-metrics"}')
+printf '%-46s %s\n' "up{job=kube-state-metrics} == 1" "$up_ksm"
+
+up_mysqld=$(q 'up{job="mysqld"}')
+printf '%-46s %s\n' "up{job=mysqld} == 1 (needs mysqld credentials)" "$up_mysqld"
+
+ready=$(q 'count(kube_node_status_condition{condition="Ready",status="true"} == 1)')
+actual=$(k get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+printf '%-46s %s\n' "KSM ready-node count vs kubectl ($actual)" "$ready"
+
+series=$(q 'prometheus_tsdb_head_series')
+printf '%-46s %s\n' "head series (weaker absolute check, budget ~2k over pre-KSM base)" "$series"
+
+etcd_age=$(q '(time() - max(kube_etcd_snapshot_creation_timestamp_seconds))')
+printf '%-46s %s\n' "etcd snapshot age seconds (fresh < 1.5x interval)" "$etcd_age"
+
+up_gaps=$(k -n danteplanner exec deploy/prometheus -- \
+  wget -qO- --post-data 'query=up{job=~"argocd|external-secrets|coredns|apiserver|etcd"}' \
+  http://localhost:9090/api/v1/query | jq -r '.data.result[] | .metric.job + "=" + .value[1]' | paste -sd' ' -)
+printf '%-46s %s\n' "gap-cluster jobs up (needs the etcd flag on live CPs)" "${up_gaps:-none}"
+
+echo
+echo "Notes: 'absent' for the etcd snapshot metric before the etcd flag is enabled (or before a snapshot has"
+echo "occurred since KSM started) is expected. The kubectl pod-level cross-check and the"
+echo "node Ready-flip drill remain manual — see manual kubectl cross-checks."

--- a/scripts/ops/provision-grafana-logs-secrets.sh
+++ b/scripts/ops/provision-grafana-logs-secrets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Store the Grafana Cloud Loki push credentials in Secrets Manager, BOTH regions.
+# Usage: h3-provision-loki.sh   (values prompted, never echoed, never on disk)
+set -euo pipefail
+
+read -rp  "Grafana Cloud Loki numeric user ID (from the stack's Loki 'Send Logs' page): " LK_USER
+read -rsp "Access-policy token with logs:write (hidden): " LK_TOKEN; echo
+
+put() {
+  local region=$1 name=$2 value=$3
+  if aws secretsmanager create-secret --region "$region" --name "$name" \
+       --secret-string "$value" >/dev/null 2>&1; then
+    echo "  created  $region  $name"
+  else
+    aws secretsmanager put-secret-value --region "$region" --secret-id "$name" \
+      --secret-string "$value" >/dev/null
+    echo "  updated  $region  $name"
+  fi
+}
+
+for region in us-west-2 ap-northeast-2; do
+  echo "== $region"
+  put "$region" danteplanner/grafana/loki-username "$LK_USER"
+  put "$region" danteplanner/grafana/loki-password "$LK_TOKEN"
+done
+echo "done — force ESO if impatient:"
+echo "  kubectl -n danteplanner annotate externalsecret grafana-loki-write force-sync=\$(date +%s) --overwrite"

--- a/scripts/ops/provision-grafana-metrics-secrets.sh
+++ b/scripts/ops/provision-grafana-metrics-secrets.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Store the Grafana Cloud remote_write credentials in Secrets
+# Manager, BOTH regions (each region's SecretStore resolves only its own).
+# Usage: h1-provision-remote-write.sh
+# Values prompted, never echoed, never written to disk — secrets never enter the repo.
+set -euo pipefail
+
+read -rp  "Grafana Cloud stack numeric ID (remote_write username): " GC_USER
+read -rsp "Access-policy token with metrics:write (hidden): " GC_TOKEN; echo
+
+put() { # region name value
+  local region=$1 name=$2 value=$3
+  if aws secretsmanager create-secret --region "$region" --name "$name" \
+       --secret-string "$value" >/dev/null 2>&1; then
+    echo "  created  $region  $name"
+  else
+    aws secretsmanager put-secret-value --region "$region" --secret-id "$name" \
+      --secret-string "$value" >/dev/null
+    echo "  updated  $region  $name"
+  fi
+}
+
+for region in us-west-2 ap-northeast-2; do
+  echo "== $region"
+  put "$region" danteplanner/grafana/remote-write-username "$GC_USER"
+  put "$region" danteplanner/grafana/remote-write-password "$GC_TOKEN"
+done
+echo "done — ESO will materialize the grafana-remote-write Secret within its 1h refresh"
+echo "(or force it: kubectl -n danteplanner annotate externalsecret grafana-remote-write force-sync=\$(date +%s) --overwrite)"

--- a/scripts/ops/provision-mysqld-secrets.sh
+++ b/scripts/ops/provision-mysqld-secrets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Create the three mysqld-exporter Secrets Manager entries in BOTH
+# regions (each region's SecretStore resolves only its own region), print the SQL
+# for the RDS monitoring user, then watch the ExternalSecret/pod heal.
+# Usage: c1-provision-secrets.sh
+# Values are prompted, never echoed, never written to disk (secrets never enter the repo).
+set -euo pipefail
+
+read -rp    "monitoring username [exporter]: " EXP_USER; EXP_USER=${EXP_USER:-exporter}
+read -rsp   "monitoring password (hidden): " EXP_PASS; echo
+read -rp    "Oregon RDS primary endpoint (host:3306): " PRIMARY_EP
+
+put() { # region name value
+  local region=$1 name=$2 value=$3
+  if aws secretsmanager create-secret --region "$region" --name "$name" \
+       --secret-string "$value" >/dev/null 2>&1; then
+    echo "  created  $region  $name"
+  else
+    aws secretsmanager put-secret-value --region "$region" --secret-id "$name" \
+      --secret-string "$value" >/dev/null
+    echo "  updated  $region  $name"
+  fi
+}
+
+for region in us-west-2 ap-northeast-2; do
+  echo "== $region"
+  put "$region" danteplanner/mysqld-exporter/username         "$EXP_USER"
+  put "$region" danteplanner/mysqld-exporter/password         "$EXP_PASS"
+  put "$region" danteplanner/mysqld-exporter/primary-endpoint "$PRIMARY_EP"
+done
+
+cat <<SQL
+
+== now create the RDS monitoring user (runs on the PRIMARY; replicates to Seoul).
+Open a client INSIDE the cluster/VPC (RDS is not publicly reachable), e.g.:
+  kubectl --kubeconfig ~/.kube/dante-oregon -n danteplanner run mysql-client \\
+    --rm -it --image=mysql:8 -- mysql -h ${PRIMARY_EP%%:*} -u admin -p
+then run:
+  CREATE USER '${EXP_USER}'@'%' IDENTIFIED BY '<the password>' WITH MAX_USER_CONNECTIONS 3;
+  GRANT PROCESS, REPLICATION CLIENT ON *.* TO '${EXP_USER}'@'%';
+  GRANT SELECT ON performance_schema.* TO '${EXP_USER}'@'%';
+SQL
+
+echo "== after the SQL, watch the exporter heal (per region):"
+echo "  kubectl --kubeconfig <kc> -n danteplanner annotate externalsecret --all force-sync=\$(date +%s) --overwrite"
+echo "  kubectl --kubeconfig <kc> -n danteplanner get externalsecret,pod -l app=mysqld-exporter"
+echo "Healthy = ExternalSecret SecretSynced, pod 1/1 Running (the CreateContainerConfigError clears itself)."

--- a/scripts/ops/rds-memory-gate.sh
+++ b/scripts/ops/rds-memory-gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# RDS FreeableMemory gate — snapshot before, compare after.
+# Usage: MIN_FREEABLE_MB=<your floor> c2-memory-gate.sh before|after <region> <db-instance-id>
+#   before: record the 5-min average FreeableMemory for the instance
+#   after : re-measure, print the delta, and verdict against YOUR floor
+# The floor (MIN_FREEABLE_MB) is deliberately not defaulted: how much headroom the
+# 1GiB t4g.micro must keep is your operational call (spec pins no number).
+set -euo pipefail
+MODE=${1:?usage: c2-memory-gate.sh before|after <region> <db-instance-id>}
+REGION=${2:?region required (us-west-2 | ap-northeast-2)}
+DB=${3:?db instance identifier required}
+STATE="/tmp/rds-memory-gate-${DB}.before"
+
+measure() {
+  aws cloudwatch get-metric-statistics --region "$REGION" \
+    --namespace AWS/RDS --metric-name FreeableMemory \
+    --dimensions Name=DBInstanceIdentifier,Value="$DB" \
+    --statistics Average --period 300 \
+    --start-time "$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+    --end-time   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --query 'sort_by(Datapoints,&Timestamp)[-1].Average' --output text
+}
+
+bytes=$(measure)
+[ "$bytes" != "None" ] || { echo "no datapoint yet — wait 5 min and retry"; exit 1; }
+mb=$(printf '%.0f' "$(echo "$bytes / 1048576" | bc -l)")
+
+case "$MODE" in
+  before)
+    echo "$mb" >"$STATE"
+    echo "recorded: ${DB} FreeableMemory ${mb} MB -> ${STATE}"
+    ;;
+  after)
+    : "${MIN_FREEABLE_MB:?set MIN_FREEABLE_MB=<floor in MB> — the go/no-go line is yours}"
+    [ -f "$STATE" ] || { echo "no before-file at ${STATE}; run 'before' first"; exit 1; }
+    before=$(cat "$STATE")
+    echo "${DB}: before=${before} MB  after=${mb} MB  drop=$((before - mb)) MB  floor=${MIN_FREEABLE_MB} MB"
+    if [ "$mb" -lt "$MIN_FREEABLE_MB" ]; then
+      echo "VERDICT: FAIL — below your floor. Replica FAIL => scale exporter to primary-only"
+      echo "(record the replica blind spot); primary FAIL => escalate before leaving it running."
+      exit 1
+    fi
+    echo "VERDICT: PASS — perf_schema cost fits."
+    ;;
+  *) echo "mode must be before|after"; exit 2;;
+esac

--- a/terraform/modules/fleet/ssm-etcd-metrics.tf
+++ b/terraform/modules/fleet/ssm-etcd-metrics.tf
@@ -1,0 +1,42 @@
+# --- etcd metrics enablement convergence ------------------------------------
+# The bootstrap passes --etcd-expose-metrics in the k3s server args, but
+# user-data runs once per instance, so CPs that predate the flag never gain
+# it. This association converges on the observable state: if :2381 already
+# serves metrics (args or config file, either source), it exits untouched;
+# only a dead endpoint triggers the config append and a k3s restart.
+resource "aws_ssm_document" "etcd_metrics" {
+  name            = "${var.name_prefix}-${var.region_name_suffix}-etcd-metrics-enable"
+  document_type   = "Command"
+  document_format = "JSON"
+  tags            = var.tags
+
+  content = jsonencode({
+    schemaVersion = "2.2"
+    description   = "Ensure the k3s embedded etcd serves metrics on :2381"
+    mainSteps = [{
+      action = "aws:runShellScript"
+      name   = "ensureEtcdMetrics"
+      inputs = {
+        runCommand = [
+          <<-EOT
+            curl -sf -m 3 http://127.0.0.1:2381/metrics >/dev/null && exit 0
+            mkdir -p /etc/rancher/k3s
+            grep -q '^etcd-expose-metrics' /etc/rancher/k3s/config.yaml 2>/dev/null \
+              || echo 'etcd-expose-metrics: true' >> /etc/rancher/k3s/config.yaml
+            systemctl restart k3s
+          EOT
+        ]
+      }
+    }]
+  })
+}
+
+resource "aws_ssm_association" "etcd_metrics" {
+  name             = aws_ssm_document.etcd_metrics.name
+  association_name = "${var.name_prefix}-${var.region_name_suffix}-etcd-metrics"
+
+  targets {
+    key    = "InstanceIds"
+    values = [aws_instance.cp.id]
+  }
+}


### PR DESCRIPTION
## Deploy-affecting changes

- **Pod logs to Grafana Cloud Loki**: one Alloy Deployment per cluster tails all pods via the kubelet API, labels streams with the region identity, and pushes to the shared Loki cell. Credentials via Secrets Manager -> ESO -> file-based basic_auth; only the shared push URL is committed. Backs the dashboard's recent WARN/ERROR list panel.
- **etcd metrics convergence**: a State Manager association keyed on observable state (a live :2381 endpoint exits untouched) covers control planes that predate the bootstrap flag; requires terraform apply per region to register.
- **Grafana provisioning kit** (deploy/grafana/): alert rules, staleness rules, delivery drill, and the fleet dashboard as repo-authoritative scripts + JSON — re-provisionable against any Grafana instance.
- **Ops scripts** (scripts/ops/): the three Secrets Manager provisioning flows matching the committed ExternalSecrets' key layouts, the RDS FreeableMemory gate, and the fleet metrics probe battery.

## Post-merge

1. Provision the Loki credentials before or after sync (scripts/ops/provision-grafana-logs-secrets.sh) — a fresh ExternalSecret reconciles immediately once values exist.
2. terraform apply in terraform/oregon and terraform/seoul to register the etcd-metrics association (first run is a no-op verification on already-enabled control planes).

Expected: alloy-logs pods Running in both regions; the WARN/ERROR logs panel populates; no restarts required anywhere.